### PR TITLE
Allow overriding of layout plugin createInitialChildren

### DIFF
--- a/packages/plugins/layout/background/src/createPlugin.tsx
+++ b/packages/plugins/layout/background/src/createPlugin.tsx
@@ -41,7 +41,7 @@ const createPlugin = (settings: BackgroundSettings) => {
     text: 'Background',
     IconComponent: <Icon />,
 
-    createInitialChildren: () => ({
+    createInitialChildren: settings.getInitialChildren || (() => ({
       id: v4(),
       rows: [
         {
@@ -57,7 +57,7 @@ const createPlugin = (settings: BackgroundSettings) => {
           ],
         },
       ],
-    }),
+    })),
 
     handleFocusNextHotKey: () => Promise.reject(),
     handleFocusPreviousHotKey: () => Promise.reject(),

--- a/packages/plugins/layout/background/src/types/settings.ts
+++ b/packages/plugins/layout/background/src/types/settings.ts
@@ -10,6 +10,7 @@ export type BackgroundSettings = {
   Controls: React.ComponentType<BackgroundControlsProps>;
   defaultPlugin: ContentPluginConfig;
   enabledModes?: ModeEnum;
+  getInitialChildren?: () => any;
   defaultBackgroundColor?: RGBColor;
   defaultGradientColor?: RGBColor;
   defaultGradientSecondaryColor?: RGBColor;

--- a/packages/plugins/layout/parallax-background/src/createPlugin.tsx
+++ b/packages/plugins/layout/parallax-background/src/createPlugin.tsx
@@ -48,7 +48,7 @@ const createPlugin: (settings: ParallaxBackgroundSettings) => LayoutPluginConfig
   text: 'Parallax Background (deprecated)',
   IconComponent: <Icon />,
 
-  createInitialChildren: () => ({
+  createInitialChildren: settings.getInitialChildren || (() => ({
     id: v4(),
     rows: [
       {
@@ -64,7 +64,7 @@ const createPlugin: (settings: ParallaxBackgroundSettings) => LayoutPluginConfig
         ],
       },
     ],
-  }),
+  })),
 
   handleFocusNextHotKey: () => Promise.reject(),
   handleFocusPreviousHotKey: () => Promise.reject(),

--- a/packages/plugins/layout/parallax-background/src/types/settings.ts
+++ b/packages/plugins/layout/parallax-background/src/types/settings.ts
@@ -6,4 +6,5 @@ export type ParallaxBackgroundSettings = {
   Renderer: React.ComponentType<ParallaxBackgroundRendererProps>;
   Controls: React.ComponentType<ParallaxBackgroundControlsProps>;
   defaultPlugin: ContentPluginConfig;
+  getInitialChildren?: () => any;
 };


### PR DESCRIPTION
The purpose of this is to allow implementers to override the initial children defaults.

This PR opens up the possibility of having a group of plugins with configurations within each other stored as a plugin which can easily be reused. For example a page section template consisting of layout, an image, spacing and text could be stored as a widget by the implementer by implementing this override

I still don't have any access to this repo so I'm working from my fork