### PR TITLE
Remove redundant build:lib steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ install:
 script:
   - yarn run lint
   - yarn run test
-  - yarn run build:lib
 
 after_success:
   - yarn run coveralls

--- a/travis-deploy.sh
+++ b/travis-deploy.sh
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 
-npm run build:lib
 cat ./packages/meta/package.json | sed s/0.0.0/$(git describe --tag)/g  > ./packages/meta/package.json
 git checkout -b release-$(git describe --tag)
 echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc


### PR DESCRIPTION
The build:lib command is already being executed when running yarn, the second time the command runs we get an error thrown on travis, not sure if it's intentional to run it 3 times when making a release but this should speed up the builds and make travis green.

I've tested in my fork and was able to release a version with this config to npm, I'm using it in production in the past weeks without any issues.

We should be able to change the namespaces and make a new release after this.