### PR TITLE
Remove parse5

### DIFF
--- a/packages/plugins/content/slate/package.json
+++ b/packages/plugins/content/slate/package.json
@@ -24,25 +24,25 @@
     "react-dom": "^16.0.0"
   },
   "dependencies": {
-    "deep-rename-keys": "^0.2.1",
-    "immutable": "3.8.2",
+    "@guestbell/slate-common": "0.3.0",
+    "@guestbell/slate-edit-blockquote": "0.3.0",
+    "@guestbell/slate-edit-list": "0.3.0",
     "@react-page/core": "0.0.0",
     "@react-page/ui": "0.0.0",
-    "parse5": "^3.0.2",
+    "deep-rename-keys": "^0.2.1",
+    "immutable": "3.8.2",
+    "is-hotkey": "0.1.4",
+    "jsdom": "^15.1.1",
+    "lodash.debounce": "4.0.8",
+    "lodash.throttle": "4.1.1",
     "ramda": "^0.24.1",
     "react-portal": "4.1.5",
     "redux-undo": "1.0.0-beta9-7",
     "slate": "^0.44.9",
-    "@guestbell/slate-common": "0.3.0",
-    "@guestbell/slate-edit-blockquote": "0.3.0",
-    "@guestbell/slate-edit-list": "0.3.0",
     "slate-html-serializer": "0.7.33",
     "slate-plain-serializer": "^0.6.33",
-    "slate-schema-violations": "0.1.39",
     "slate-react": "^0.21.15",
-    "lodash.throttle": "4.1.1",
-    "lodash.debounce": "4.0.8",
-    "is-hotkey": "0.1.4"
+    "slate-schema-violations": "0.1.39"
   },
   "publishConfig": {
     "access": "public"
@@ -50,5 +50,8 @@
   "devDependencies": {
     "@types/is-hotkey": "0.1.1",
     "@types/lodash.debounce": "4.0.4"
+  },
+  "browser": {
+    "jsdom": false
   }
 }

--- a/packages/plugins/content/slate/src/Controls/index.tsx
+++ b/packages/plugins/content/slate/src/Controls/index.tsx
@@ -30,9 +30,14 @@ import { BottomToolbar, ThemeProvider } from '@react-page/ui';
 import debounce from 'lodash.debounce';
 
 import { Value, Editor as CoreEditor } from 'slate';
-import { Cancelable } from 'lodash';
+
 import { SlateProps } from 'src/types/component';
 import Plugin, { PluginButtonProps } from 'src/plugins/Plugin';
+
+interface Cancelable {
+  cancel(): void;
+  flush(): void;
+}
 
 const theme = createMuiTheme({
   palette: {

--- a/packages/plugins/content/slate/src/plugins/link/index.tsx
+++ b/packages/plugins/content/slate/src/plugins/link/index.tsx
@@ -79,11 +79,7 @@ export default class LinkPlugin extends Plugin {
           type: A,
           nodes: next(el.childNodes),
           data: Data.create({
-            href: (
-              el.attrs.find(({ name }) => name === 'href') || {
-                value: '',
-              }
-            ).value,
+            href: el.getAttribute('href') || '',
           }),
         };
       default:

--- a/packages/plugins/content/slate/src/serialization/index.tsx
+++ b/packages/plugins/content/slate/src/serialization/index.tsx
@@ -1,12 +1,13 @@
 import Html from 'slate-html-serializer';
-import React from 'react';
-import parse5 from 'parse5';
+
 import { SlateState } from '../types/state';
 import { Value, ValueJSON } from 'slate';
 
 import { EditorState } from '@react-page/core/lib/types/editor';
 import { PluginProps } from '@react-page/core/lib/service/plugin/classes';
 import createInitialState from './createInitialState';
+
+const parseHtml = require('jsdom').fragment; // we exclude that on browsers through package.json's browser field
 
 type AdditionalSlateFunctions = {
   slateToHtml: (editorState: EditorState) => string;
@@ -18,39 +19,12 @@ export type SerializationFunctions = Pick<
 > &
   AdditionalSlateFunctions;
 export default ({ plugins }): SerializationFunctions => {
-  const lineBreakSerializer = {
-    // tslint:disable-next-line:no-any
-    deserialize(el: any) {
-      if (el.tagName.toLowerCase() === 'br') {
-        return { object: 'text', text: '\n' };
-      }
-      if (el.nodeName === '#text') {
-        if (el.value && el.value.match(/<!--.*?-->/)) {
-          return;
-        }
-
-        return {
-          object: 'text',
-          leaves: [
-            {
-              object: 'leaf',
-              text: el.value,
-            },
-          ],
-        };
-      }
-    },
-    // tslint:disable-next-line:no-any
-    serialize(object: any, children: string) {
-      if (object.type === 'text' || children === '\n') {
-        return <br />;
-      }
-    },
-  };
+  // tslint:disable-next-line:no-any
 
   const html = new Html({
-    rules: [...plugins, lineBreakSerializer],
-    parseHtml: parse5.parseFragment,
+    rules: plugins,
+    // tslint:disable-next-line:no-any
+    parseHtml,
   });
 
   const htmlToSlate = (htmlString: string) => html.deserialize(htmlString);


### PR DESCRIPTION
remove parse5 and replace it with jsdom on server and in tests. This reduces the bundle size by around 200kb.

also parse5 is not supported anymore by slate officially, altough it did not seem to have caused problems.

based on my previous refactor https://github.com/react-page/react-page/pull/700


we should merge that and then i will do a rebase here