### PR TITLE
feat: allow to define whether link should open in new window

### DIFF
--- a/packages/plugins/content/slate/src/default/settings.ts
+++ b/packages/plugins/content/slate/src/default/settings.ts
@@ -10,6 +10,7 @@ export const defaultTranslations = {
     createLink: 'Create a link',
     linkTitlePlaceholder: 'Link title',
     linkHrefPlaceholder: 'http://example.com/my/link.html',
+    linkOpenInNewWindowLabel: 'Open in new window',
   },
 };
 

--- a/packages/plugins/content/slate/src/plugins/link/Controls.tsx
+++ b/packages/plugins/content/slate/src/plugins/link/Controls.tsx
@@ -1,0 +1,192 @@
+/*
+ * This file is part of ORY Editor.
+ *
+ * ORY Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ORY Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with ORY Editor.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @license LGPL-3.0
+ * @copyright 2016-2018 Aeneas Rekkas
+ * @author Aeneas Rekkas <aeneas+oss@aeneas.io>
+ *
+ */
+
+/* eslint-disable no-alert, prefer-reflect, default-case, react/display-name */
+
+import * as React from 'react';
+import TextField from '@material-ui/core/TextField';
+import Checkbox from '@material-ui/core/Checkbox';
+
+import { PluginButtonProps } from '../Plugin';
+
+import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogActions from '@material-ui/core/DialogActions';
+import Button from '@material-ui/core/Button';
+import { FormControlLabel } from '@material-ui/core';
+
+const A = 'LINK/LINK';
+export interface LinkControlsState {
+  href: string;
+  title: string;
+  openInNewWindow: boolean;
+}
+export interface Props {
+  open: boolean;
+  close: () => void;
+}
+
+class Controls extends React.Component<
+  Props & PluginButtonProps,
+  LinkControlsState
+> {
+  state = {
+    href: '',
+    title: '',
+    openInNewWindow: false,
+  };
+
+  input: HTMLDivElement;
+
+  onRef = (component: HTMLDivElement) => {
+    if (!component && true) {
+      return null;
+    }
+
+    const e = component.querySelector('input');
+    if (e) {
+      e.focus();
+    }
+  }
+
+  textIsSelected = () => {
+    return this.props.editorState.selection.isExpanded;
+  }
+
+  handleClose = () => {
+    this.props.close();
+    this.props.editor.focus();
+  }
+
+  handleSubmit = () => {
+    this.props.close();
+
+    if (!this.state.href) {
+      this.handleClose();
+      return;
+    }
+
+    const data = {
+      href: this.state.href,
+      openInNewWindow: this.state.openInNewWindow,
+    };
+
+    if (this.textIsSelected()) {
+      this.props.editor
+        .focus()
+        .wrapInline({
+          type: A,
+          data,
+        })
+        .moveToEnd();
+      return;
+    } else {
+      // no text is selected. so we need a title
+      if (!this.state.title) {
+        this.handleClose();
+        return;
+      }
+      this.props.editor
+        .insertText(this.state.title)
+        .moveFocusBackward(this.state.title.length)
+        .wrapInline({
+          type: A,
+          data,
+        })
+        .moveToEnd()
+        .focus();
+    }
+  }
+
+  onHrefChange = e => {
+    this.setState({ href: e.target.value });
+  }
+
+  onTitleChange = e => {
+    this.setState({ title: e.target.value });
+  }
+
+  onOpenInNewWindowChange = (e, checked) => {
+    this.setState({ openInNewWindow: checked });
+  }
+
+  render() {
+    const actions = (
+      <React.Fragment>
+        <Button variant="text" color="primary" onClick={this.handleClose}>
+          {this.props.translations.linkPlugin!.cancel}
+        </Button>
+        <Button variant="text" color="primary" onClick={this.handleSubmit}>
+          {this.props.translations.linkPlugin!.ok}
+        </Button>
+      </React.Fragment>
+    );
+
+    return (
+      <Dialog
+        className="ory-prevent-blur"
+        title={this.props.translations.linkPlugin!.createLink}
+        // modal={false}
+        open={this.props.open}
+      >
+        <DialogTitle id="confirmation-dialog-title">
+          {this.props.translations.linkPlugin!.createLink}
+        </DialogTitle>
+        <DialogContent>
+          {this.textIsSelected() ? null : (
+            <div>
+              <TextField
+                placeholder={
+                  this.props.translations.linkPlugin!.linkTitlePlaceholder
+                }
+                onChange={this.onTitleChange}
+                value={this.state.title}
+              />
+            </div>
+          )}
+          <div ref={this.onRef}>
+            <TextField
+              placeholder={
+                this.props.translations.linkPlugin!.linkHrefPlaceholder
+              }
+              onChange={this.onHrefChange}
+              value={this.state.href}
+            />
+          </div>
+          <FormControlLabel
+            control={
+              <Checkbox
+                onChange={this.onOpenInNewWindowChange}
+                value={this.state.openInNewWindow}
+              />
+            }
+            label={this.props.translations.linkPlugin!.linkOpenInNewWindowLabel}
+          />
+        </DialogContent>
+        <DialogActions>{actions}</DialogActions>
+      </Dialog>
+    );
+  }
+}
+
+export default Controls;

--- a/packages/plugins/content/slate/src/plugins/link/LinkButton.tsx
+++ b/packages/plugins/content/slate/src/plugins/link/LinkButton.tsx
@@ -23,51 +23,30 @@
 /* eslint-disable no-alert, prefer-reflect, default-case, react/display-name */
 import LinkIcon from '@material-ui/icons/Link';
 import * as React from 'react';
-import TextField from '@material-ui/core/TextField';
 import { ToolbarButton } from '../../helpers';
 import { PluginButtonProps } from '../Plugin';
 
-import Dialog from '@material-ui/core/Dialog';
-import DialogTitle from '@material-ui/core/DialogTitle';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogActions from '@material-ui/core/DialogActions';
-import Button from '@material-ui/core/Button';
+import Controls from './Controls';
 import { Inline } from 'slate';
 import { ThemeProvider } from '@react-page/ui';
 
 const A = 'LINK/LINK';
 export interface LinkButtonState {
   open: boolean;
-  href: string;
-  title: string;
-  hadLinks: boolean;
-  wasExpanded: boolean;
 }
 
 class LinkButton extends React.Component<PluginButtonProps, LinkButtonState> {
   state = {
     open: false,
-    href: '',
-    title: '',
-    hadLinks: false,
-    wasExpanded: false,
   };
 
-  input: HTMLDivElement;
-
-  onRef = (component: HTMLDivElement) => {
-    if (!component && true) {
-      return null;
-    }
-
-    const e = component.querySelector('input');
-    if (e) {
-      e.focus();
-    }
+  removeLink() {
+    const { editor } = this.props;
+    editor.unwrapInline(A);
   }
 
-  onClick = e => {
-    const { editorState, editor } = this.props;
+  onClick = (e: React.MouseEvent<HTMLElement>) => {
+    const { editorState } = this.props;
     e.preventDefault();
 
     const hasLinks = editorState.inlines.some(
@@ -75,85 +54,17 @@ class LinkButton extends React.Component<PluginButtonProps, LinkButtonState> {
     );
 
     if (hasLinks) {
-      editor.unwrapInline(A);
-    } else if (editorState.selection.isExpanded) {
-      this.setState({
-        open: true,
-        wasExpanded: editorState.selection.isExpanded,
-        href: '',
-        title: '',
-        hadLinks: hasLinks,
-      });
+      this.removeLink();
     } else {
-      this.setState({
-        open: true,
-        wasExpanded: editorState.selection.isExpanded,
-        href: '',
-        title: '',
-        hadLinks: hasLinks,
-      });
+      this.setState({ open: true });
     }
   }
 
-  handleClose = () => {
+  close = () => {
     this.setState({ open: false });
-    this.props.editor.focus();
-  }
-
-  handleSubmit = () => {
-    this.setState({ open: false });
-
-    if (!this.state.href) {
-      this.handleClose();
-      return;
-    }
-
-    if (this.state.wasExpanded) {
-      this.props.editor
-        .focus()
-        .wrapInline({
-          type: A,
-          data: { href: this.state.href },
-        })
-        .moveToEnd();
-      return;
-    }
-
-    if (!this.state.title) {
-      this.handleClose();
-      return;
-    }
-
-    this.props.editor
-      .insertText(this.state.title)
-      .moveFocusBackward(this.state.title.length)
-      .wrapInline({
-        type: A,
-        data: { href: this.state.href },
-      })
-      .moveToEnd()
-      .focus();
-  }
-
-  onHrefChange = e => {
-    this.setState({ href: e.target.value });
-  }
-
-  onTitleChange = e => {
-    this.setState({ title: e.target.value });
   }
 
   render() {
-    const actions = (
-      <React.Fragment>
-        <Button variant="text" color="primary" onClick={this.handleClose}>
-          {this.props.translations.linkPlugin!.cancel}
-        </Button>
-        <Button variant="text" color="primary" onClick={this.handleSubmit}>
-          {this.props.translations.linkPlugin!.ok}
-        </Button>
-      </React.Fragment>
-    );
     const { editorState } = this.props;
 
     const hasLinks = editorState.inlines.some(
@@ -161,48 +72,15 @@ class LinkButton extends React.Component<PluginButtonProps, LinkButtonState> {
     );
     return (
       <ThemeProvider>
-        <span>
+        <>
           <ToolbarButton
             onClick={this.onClick}
             isActive={hasLinks}
             icon={<LinkIcon />}
           />
-          <span>
-            <Dialog
-              className="ory-prevent-blur"
-              title={this.props.translations.linkPlugin!.createLink}
-              // modal={false}
-              open={this.state.open}
-            >
-              <DialogTitle id="confirmation-dialog-title">
-                {this.props.translations.linkPlugin!.createLink}
-              </DialogTitle>
-              <DialogContent>
-                {this.state.wasExpanded ? null : (
-                  <div>
-                    <TextField
-                      placeholder={
-                        this.props.translations.linkPlugin!.linkTitlePlaceholder
-                      }
-                      onChange={this.onTitleChange}
-                      value={this.state.title}
-                    />
-                  </div>
-                )}
-                <div ref={this.onRef}>
-                  <TextField
-                    placeholder={
-                      this.props.translations.linkPlugin!.linkHrefPlaceholder
-                    }
-                    onChange={this.onHrefChange}
-                    value={this.state.href}
-                  />
-                </div>
-              </DialogContent>
-              <DialogActions>{actions}</DialogActions>
-            </Dialog>
-          </span>
-        </span>
+
+          <Controls close={this.close} open={this.state.open} {...this.props} />
+        </>
       </ThemeProvider>
     );
   }

--- a/packages/plugins/content/slate/src/plugins/link/index.tsx
+++ b/packages/plugins/content/slate/src/plugins/link/index.tsx
@@ -40,7 +40,14 @@ export const A = 'LINK/LINK';
 const ALLOWED_TYPES = [A];
 
 const DEFAULT_MAPPING = {
-  [A]: 'a',
+  [A]: ({ children, data }) => (
+    <a
+      target={data.get('openInNewWindow') ? '_blank' : undefined}
+      href={data.get('href')}
+    >
+      {children}
+    </a>
+  ),
 };
 
 // tslint:disable-next-line:no-any
@@ -105,7 +112,7 @@ export default class LinkPlugin extends Plugin {
     if (!Component) {
       return null;
     }
-    return <Component href={object.data.get('href')}>{children}</Component>;
+    return <Component data={object.data} children={children} />;
   }
 
   renderNode = (props: RenderNodeProps, editor: Editor, next: NextType) => {
@@ -118,11 +125,7 @@ export default class LinkPlugin extends Plugin {
       data: props.node.data,
     });
     if (Component) {
-      return (
-        <Component href={props.node.data.get('href')}>
-          {props.children}
-        </Component>
-      );
+      return <Component data={props.node.data} children={props.children} />;
     }
 
     return next();


### PR DESCRIPTION
slate link plugin now allow to define whether links should open in a new window

I added it while doing a refactor of the link plugin. I later want to allow for more complex plugins, like page links which store a pageId instead of a href and generate the href on render. The slate plugins are still a bit verbose and therefore hard to extend or customize. The goal is to have a similar flexibility like  with `@react-page/create-plugin-materialui`

## Proposed changes

slate link plugin has a checkbox which defines whether link opens in new window (`target="_blank"`)



## Types of changes

<!-- What types of changes does your code introduce to react-page? -->
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Its *a little breaking*, but only if you override `getComponent` of the link plugin, which was a brand-new feature..

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Lint and unit tests pass locally with my changes
- [  I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules


