### PR TITLE
extended serialize and unserialize functions of slate plugin to handle also other props

### DIFF
--- a/packages/plugins/content/slate/src/serialization/index.tsx
+++ b/packages/plugins/content/slate/src/serialization/index.tsx
@@ -42,26 +42,29 @@ export default ({ plugins }: { plugins: SlatePlugin[] }) => {
     importFromHtml,
     serialized,
     editorState,
+    ...rest
   }: // tslint:disable-next-line:no-any
   SlateState): SlateState => {
     if (serialized) {
       // tslint:disable-next-line:no-any
-      return { editorState: (Value.fromJSON as any)(serialized) };
+      return { editorState: (Value.fromJSON as any)(serialized), ...rest };
     } else if (importFromHtml) {
-      return { editorState: htmlToSlate(importFromHtml) };
+      return { editorState: htmlToSlate(importFromHtml), ...rest };
     } else if (editorState) {
-      return { editorState };
+      return { editorState, ...rest };
     }
 
-    return createInitialState();
+    return { ...createInitialState(), ...rest };
   };
 
   // tslint:disable-next-line:no-any
   const serialize = ({
     editorState,
+    ...rest
   }: SlateState): { serialized: ValueJSON } => ({
     // tslint:disable-next-line:no-any
     serialized: (editorState.toJSON as any)(editorState),
+    ...rest,
   });
 
   return {


### PR DESCRIPTION
Like discussed in https://github.com/react-page/react-page/issues/721 it is neccessary to (un)serialize also other props than editorState of slate to allow wrapping other components arround slate.
