### PR TITLE
feat: easier createInitialChildren for layout plugins

### DIFF
--- a/docs/plugins/create.md
+++ b/docs/plugins/create.md
@@ -30,7 +30,6 @@ Most built-in plugins use a bottom toolbar with a form as Controls. See for exam
 
 Plugins have two parts, one plugin definition and a ReactJS component. A minimal plugin definition looks as followed
 
-
 ```jsx
 import React, { Component } from "react";
 
@@ -96,7 +95,6 @@ Make sure the `onChange` prop is never passed through to an HTML element (eg via
 
 A layout plugin will require an initial children, otherwise, it will automatically destroyed. A minimal layout plugin definition looks as follows
 
-
 ```jsx
 import React from "react";
 import slate from "@react-page/plugins-slate";
@@ -115,23 +113,14 @@ export default {
   name: "example/layout/black-border",
   version: "0.0.1",
   text: "Black border",
-  createInitialChildren: () => ({
-    id: v4(),
-    rows: [
+  createInitialChildren: () => [
+    [
       {
-        id: v4(),
-        cells: [
-          {
-            content: {
-              plugin: slate(),
-              state: slate().createInitialState()
-            },
-            id: v4()
-          }
-        ]
+        content: { plugin: slate() }
+        // or another layout plugin: layout: { plugin: someLayoutPlugin() }
       }
     ]
-  })
+  ]
 };
 ```
 

--- a/examples/src/customLayoutPlugin.tsx
+++ b/examples/src/customLayoutPlugin.tsx
@@ -1,38 +1,42 @@
 import { createLayoutPlugin } from '@react-page/create-plugin-materialui';
 import React from 'react';
-import { v4 } from 'uuid';
-// tslint:disable-next-line:no-any
-const createInitialChildren = ({ defaultPlugin }: any) => ({
-  id: v4(),
-  rows: [
-    {
-      id: v4(),
-      cells: [
-        {
-          content: defaultPlugin
-            ? {
-                plugin: defaultPlugin,
-                state: defaultPlugin.createInitialState(),
-              }
-            : null,
-          id: v4(),
-        },
-      ],
-    },
-  ],
-});
+
 // tslint:disable-next-line:no-any
 export default (settings: any) =>
   createLayoutPlugin({
     ...settings,
     // tslint:disable-next-line:no-any
     Renderer: ({ children, state }: any) => (
-      <div style={{ backgroundColor: state.backgroundColor }}>{children}</div>
+      <div
+        style={{
+          border: '1px solid black',
+          backgroundColor: state.backgroundColor,
+        }}
+      >
+        {children}
+      </div>
     ),
-    createInitialChildren: () =>
-      createInitialChildren({
-        defaultPlugin: settings.defaultPlugin,
-      }),
+    createInitialChildren: () => {
+      return [
+        [
+          {
+            content: { plugin: settings.defaultPlugin },
+          },
+          {
+            content: { plugin: settings.defaultPlugin },
+          },
+        ],
+        [
+          {
+            content: { plugin: settings.defaultPlugin },
+          },
+          {
+            content: { plugin: settings.defaultPlugin },
+          },
+        ],
+      ];
+    },
+
     name: 'custom-layout-plugin',
     text: 'Custom layout plugin',
     description: 'Some custom layout plugin',

--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -74,10 +74,9 @@ import { ImageUploadType } from '@react-page/ui/lib/ImageUpload/types';
 import { Plugins } from '@react-page/core';
 import customSlatePlugin from './customSlatePlugin';
 
-const fakeImageUploadService: (url: string) => ImageUploadType = defaultUrl => (
-  file,
-  reportProgress
-) => {
+const fakeImageUploadService: (
+  url: string
+) => ImageUploadType = defaultUrl => (file, reportProgress) => {
   return new Promise((resolve, reject) => {
     let counter = 0;
     const interval = setInterval(() => {

--- a/packages/core/src/helper/createInitialChildren/index.ts
+++ b/packages/core/src/helper/createInitialChildren/index.ts
@@ -1,0 +1,68 @@
+import {
+  ContentPlugin,
+  ContentPluginConfig,
+  LayoutPlugin,
+  LayoutPluginConfig
+} from '../../service/plugin/classes';
+import { v4 } from 'uuid';
+
+type CellDef = {
+  content?: {
+    plugin: ContentPluginConfig;
+    state?: object;
+  };
+  layout?: {
+    plugin: LayoutPluginConfig;
+    state?: object;
+  };
+};
+export type RowDef = CellDef[];
+
+export type ChildrenDef = {
+  id: string;
+  rows: {
+    id: string;
+    cells: {
+      id: string;
+      content?: {
+        plugin: ContentPlugin;
+        state?: object;
+      };
+      layout?: {
+        plugin: LayoutPlugin;
+        state?: object;
+      };
+    }[];
+  }[];
+};
+
+export type InitialChildrenDef = RowDef[] | ChildrenDef;
+
+const withDefaultState = (
+  layoutOrContent: CellDef['layout'] | CellDef['content'],
+  PluginClass
+) => {
+  const plugin = new PluginClass(layoutOrContent.plugin);
+  return {
+    plugin,
+    state: layoutOrContent.state || plugin.createInitialState(),
+  };
+};
+
+export default (rows: RowDef[]): ChildrenDef => ({
+  id: v4(),
+  rows: rows.map(row => ({
+    id: v4(),
+    cells: row.map(cell => {
+      return {
+        id: v4(),
+        layout: cell.layout
+          ? withDefaultState(cell.layout, LayoutPlugin)
+          : undefined,
+        content: cell.content
+          ? withDefaultState(cell.content, ContentPlugin)
+          : undefined,
+      };
+    }),
+  })),
+});

--- a/packages/core/src/helper/sanitizeInitialChildren/index.ts
+++ b/packages/core/src/helper/sanitizeInitialChildren/index.ts
@@ -1,0 +1,10 @@
+import createInitialChildren, {
+  InitialChildrenDef
+} from '../createInitialChildren';
+
+export default (childrenOrRowDef: InitialChildrenDef) => {
+  if (Array.isArray(childrenOrRowDef)) {
+    return createInitialChildren(childrenOrRowDef);
+  }
+  return childrenOrRowDef;
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,22 +38,41 @@ import { RootState } from './types/state';
 import lazyLoad from './helper/lazyLoad';
 import {
   Plugins,
+  Plugin,
   ContentPluginConfig,
-  LayoutPluginConfig
+  LayoutPluginConfig,
+  ContentPluginProps,
+  LayoutPluginProps
 } from './service/plugin/classes';
 import { isProduction } from './const';
 import { shouldPureComponentUpdate } from './helper/shouldComponentUpdate';
 export { shouldPureComponentUpdate };
 import i18n from './service/i18n';
+import { InitialChildrenDef } from './helper/createInitialChildren';
+import sanitizeInitialChildren from './helper/sanitizeInitialChildren';
 import DragDropContext from './components/DragDropContext';
 export {
+  Plugin,
   Plugins,
+  ContentPluginConfig,
+  ContentPluginProps,
+  LayoutPluginConfig,
+  LayoutPluginProps,
   NativeFactory,
   Actions,
   Selectors,
   RootState,
   i18n,
-  DragDropContext
+  DragDropContext,
+  InitialChildrenDef,
+  sanitizeInitialChildren,
+  PluginService,
+  ContentPlugin,
+  LayoutPlugin,
+  Editable,
+  Editor,
+  reducer,
+  lazyLoad
 };
 let instance: Editor;
 
@@ -156,47 +175,69 @@ class Editor<T extends RootState = RootState> {
     }, this.store.getState().reactPage.editables.present);
   }
 
-  // tslint:disable-next-line:no-any
+  /**
+   * @deprecated in order to reduce the api surface, we will remove this method in the future
+   */
   public setLayoutPlugins = (plugins: LayoutPluginConfig[] = []) => {
+    console.warn(
+      'in order to reduce the api surface, we will remove setLayoutPlugins in the future'
+    );
     this.plugins.setLayoutPlugins(plugins);
     this.refreshEditables();
   }
-
+  /**
+   * @deprecated in order to reduce the api surface, we will remove this method in the future
+   */
   public addLayoutPlugin = (config: LayoutPluginConfig) => {
+    console.warn(
+      'in order to reduce the api surface, we will remove addLayoutPlugin in the future'
+    );
     this.plugins.addLayoutPlugin(config);
     this.refreshEditables();
   }
-
+  /**
+   * @deprecated in order to reduce the api surface, we will remove this method in the future
+   */
   public removeLayoutPlugin = (name: string) => {
+    console.warn(
+      'in order to reduce the api surface, we will remove removeLayoutPlugin in the future'
+    );
     this.plugins.removeLayoutPlugin(name);
     this.refreshEditables();
   }
-
+  /**
+   * @deprecated in order to reduce the api surface, we will remove this method in the future
+   */
   public setContentPlugins = (plugins: ContentPluginConfig[] = []) => {
+    console.warn(
+      'in order to reduce the api surface, we will remove setContentPlugins in the future'
+    );
     this.plugins.setContentPlugins(plugins);
     this.refreshEditables();
   }
 
+  /**
+   * @deprecated in order to reduce the api surface, we will remove this method in the future
+   */
   public addContentPlugin = (config: ContentPluginConfig) => {
+    console.warn(
+      'in order to reduce the api surface, we will remove addContentPlugin in the future'
+    );
     this.plugins.addContentPlugin(config);
     this.refreshEditables();
   }
 
+  /**
+   * @deprecated in order to reduce the api surface, we will remove this method in the future
+   */
   public removeContentPlugin = (name: string) => {
+    console.warn(
+      'in order to reduce the api surface, we will remove removeContentPlugin in the future'
+    );
     this.plugins.removeContentPlugin(name);
     this.refreshEditables();
   }
 }
-
-export {
-  PluginService,
-  ContentPlugin,
-  LayoutPlugin,
-  Editable,
-  Editor,
-  reducer,
-  lazyLoad
-};
 
 export const createEmptyState: () => EditableType = () =>
   ({ id: v4(), cells: [] } as EditableType);

--- a/packages/core/src/service/plugin/classes.ts
+++ b/packages/core/src/service/plugin/classes.ts
@@ -24,6 +24,7 @@ import semver from 'semver';
 import { AnyAction } from 'redux';
 import { Omit } from '../../types/omit';
 import { NativeFactory, AbstractCell } from '../../types/editable';
+import { InitialChildrenDef } from '../../helper/createInitialChildren';
 
 export type Plugins = {
   layout?: LayoutPluginConfig[];
@@ -119,7 +120,7 @@ export type ContentPluginProps<
 // tslint:disable-next-line:no-any
 export type LayoutPluginExtraProps<T = any> = {
   // tslint:disable-next-line:no-any
-  createInitialChildren?: () => any;
+  createInitialChildren?: () => InitialChildrenDef;
 
   Component?: PluginComponentType<LayoutPluginProps<T>>;
 };
@@ -513,14 +514,14 @@ export class LayoutPlugin<StateT = any> extends Plugin<
    * @returns the initial state.
    */
   // tslint:disable-next-line:no-any
-  createInitialChildren = (): any => ({} as any);
+  createInitialChildren = (): InitialChildrenDef => [];
 }
 
 // tslint:disable-next-line:no-any
 export type NativePluginProps<StateT = any> = PluginProps<StateT> & {
   type?: string;
   // tslint:disable-next-line:no-any
-  createInitialChildren?: () => any;
+  createInitialChildren?: () => InitialChildrenDef;
   allowInlineNeighbours?: boolean;
   isInlineable?: boolean;
 };
@@ -567,7 +568,7 @@ export class NativePlugin<StateT> extends Plugin<StateT> {
    *
    * @returns the initial state.
    */
-  createInitialChildren = (): Object => ({});
+  createInitialChildren = (): InitialChildrenDef => [];
 
   /**
    * Create the plugin's initial state.

--- a/packages/core/src/service/plugin/default.tsx
+++ b/packages/core/src/service/plugin/default.tsx
@@ -36,7 +36,7 @@ const Default: React.SFC<ContentPluginProps<{ value: string }>> = ({
   readOnly,
   state: { value },
   onChange,
-})  =>
+}) =>
   readOnly ? (
     <div>{value}</div>
   ) : (
@@ -50,6 +50,7 @@ const Default: React.SFC<ContentPluginProps<{ value: string }>> = ({
 const _defaultContentPlugin: ContentPluginConfig<{}> = {
   Component: Default,
   name: 'ory/editor/core/default',
+  
   version: '0.0.1',
   createInitialState: () => ({
     value:

--- a/packages/core/src/service/plugin/index.ts
+++ b/packages/core/src/service/plugin/index.ts
@@ -28,13 +28,11 @@ import {
   Plugin,
   NativePlugin,
   NativePluginProps,
-  LayoutPluginProps,
-  ContentPluginProps,
   Plugins,
   LayoutPluginConfig,
   PluginConfig,
   PluginsInternal,
-  ContentPluginConfig,
+  ContentPluginConfig
 } from './classes';
 import { ComponetizedCell, EditableType } from '../../types/editable';
 import defaultPlugin from './default';
@@ -69,11 +67,7 @@ export default class PluginService {
   /**
    * Instantiate a new PluginService instance. You can provide your own set of content and layout plugins here.
    */
-  constructor({
-    content = [],
-    layout = [],
-    native,
-  }: Plugins = {} as Plugins) {
+  constructor({ content = [], layout = [], native }: Plugins = {} as Plugins) {
     this.plugins = {
       content: [defaultPlugin, ...content].map(
         // tslint:disable-next-line:no-any
@@ -130,7 +124,7 @@ export default class PluginService {
 
   removeLayoutPlugin = (name: string) => {
     this.plugins.layout = this.plugins.layout.filter(
-      (plugin: LayoutPluginConfig) => plugin.name !== name
+      plugin => plugin.name !== name
     );
   }
 
@@ -149,7 +143,7 @@ export default class PluginService {
 
   removeContentPlugin = (name: string) => {
     this.plugins.content = this.plugins.content.filter(
-      (plugin: ContentPlugin) => plugin.name !== name
+      plugin => plugin.name !== name
     );
   }
 
@@ -160,15 +154,15 @@ export default class PluginService {
     name: string,
     version: string
   ): { plugin: LayoutPlugin; pluginWrongVersion?: LayoutPlugin } => {
-    const plugin = this.plugins.layout.find(find(name, version)) as LayoutPlugin;
+    const plugin = this.plugins.layout.find(
+      find(name, version)
+    ) as LayoutPlugin;
     let pluginWrongVersion = undefined;
     if (!plugin) {
       pluginWrongVersion = this.plugins.layout.find(find(name, '*'));
     }
     return {
-      plugin:
-        plugin ||
-        new LayoutPlugin(layoutMissing({ name, version } as LayoutPluginProps)),
+      plugin: plugin || new LayoutPlugin(layoutMissing({ name, version })),
       pluginWrongVersion,
     };
   }
@@ -186,11 +180,7 @@ export default class PluginService {
       pluginWrongVersion = this.plugins.content.find(find(name, '*'));
     }
     return {
-      plugin:
-        plugin ||
-        new ContentPlugin(
-          contentMissing({ name, version } as ContentPluginProps)
-        ),
+      plugin: plugin || new ContentPlugin(contentMissing({ name, version })),
       pluginWrongVersion,
     };
   }
@@ -233,11 +223,15 @@ export default class PluginService {
     return state;
   }
 
-  // tslint:disable-next-line:no-any
-  getNewPluginState = (found: { plugin: Plugin; pluginWrongVersion?: Plugin }, state: any, version: string): {
-    plugin: Plugin,
+  getNewPluginState = (
+    found: { plugin: Plugin; pluginWrongVersion?: Plugin },
     // tslint:disable-next-line:no-any
-    state: any
+    state: any,
+    version: string
+  ): {
+    plugin: Plugin;
+    // tslint:disable-next-line:no-any
+    state: any;
   } => {
     if (
       !found.pluginWrongVersion ||

--- a/packages/core/src/service/plugin/missing.tsx
+++ b/packages/core/src/service/plugin/missing.tsx
@@ -21,7 +21,11 @@
  */
 
 import * as React from 'react';
-import { ContentPluginProps, LayoutPluginProps } from './classes';
+import {
+  LayoutPluginConfig,
+  ContentPluginConfig,
+  ContentPluginProps
+} from './classes';
 
 const ContentMissingComponent = (props: ContentPluginProps<{}>) => (
   <div
@@ -38,11 +42,14 @@ const ContentMissingComponent = (props: ContentPluginProps<{}>) => (
   </div>
 );
 
-export const contentMissing = (
-  plugin: ContentPluginProps
-): ContentPluginProps => ({
+export const contentMissing = ({
+  name,
+  version,
+}: Pick<ContentPluginConfig, 'name' | 'version'>): ContentPluginConfig => ({
   Component: ContentMissingComponent,
-  ...plugin,
+
+  name,
+  version,
 });
 
 const LayoutMissingComponent: React.SFC = ({ children, ...props }) => (
@@ -63,8 +70,12 @@ const LayoutMissingComponent: React.SFC = ({ children, ...props }) => (
   </div>
 );
 
-export const layoutMissing = (plugin: LayoutPluginProps): LayoutPluginProps =>
-  ({
-    Component: LayoutMissingComponent,
-    ...plugin,
-  } as LayoutPluginProps);
+export const layoutMissing = ({
+  name,
+  version,
+}: Pick<LayoutPluginConfig, 'name' | 'version'>): LayoutPluginConfig => ({
+  Component: LayoutMissingComponent,
+
+  name,
+  version,
+});

--- a/packages/core/src/types/editable.ts
+++ b/packages/core/src/types/editable.ts
@@ -24,7 +24,6 @@ import * as React from 'react';
 import {
   ContentPlugin,
   LayoutPlugin,
-  ContentPluginProps,
   NativePluginConfig,
   ContentPluginConfig,
   LayoutPluginConfig
@@ -217,7 +216,7 @@ export type EditableComponentState = {
   isEditMode: boolean;
   isLayoutMode: boolean;
   isPreviewMode: boolean;
-  defaultPlugin: ContentPluginProps;
+  defaultPlugin: ContentPluginConfig;
 
   blurAllCells(): void;
   createFallbackCell(plugin: ContentPlugin | LayoutPlugin, id: string): void;

--- a/packages/plugins/content/divider/src/createPlugin.tsx
+++ b/packages/plugins/content/divider/src/createPlugin.tsx
@@ -24,6 +24,7 @@ const createPlugin: (
     IconComponent: <Remove />,
     text: mergedSettings.translations.pluginName,
     description: mergedSettings.translations.pluginDescription,
+    
   };
 };
 

--- a/packages/plugins/content/html5-video/src/createPlugin.tsx
+++ b/packages/plugins/content/html5-video/src/createPlugin.tsx
@@ -49,6 +49,7 @@ const createPlugin: (
     <Html5Video {...props} {...mergedSettings} />
   );
   return {
+    
     Component: WrappedComponent,
     name: 'ory/sites/plugin/content/html5-video',
     version: '0.0.1',

--- a/packages/plugins/content/image/src/createPlugin.tsx
+++ b/packages/plugins/content/image/src/createPlugin.tsx
@@ -41,6 +41,7 @@ const createPlugin = (
     Component: (props: ContentPluginProps<ImageState>) => (
       <Component {...props} {...mergedSettings} />
     ),
+    
     name: 'ory/editor/core/content/image',
     version: '0.0.1',
     IconComponent: <Panorama />,

--- a/packages/plugins/content/slate/src/index.tsx
+++ b/packages/plugins/content/slate/src/index.tsx
@@ -94,6 +94,7 @@ export default (
   });
 
   return {
+    
     Component: (props: SlateProps) => (
       <Component
         Renderer={settings.Renderer}

--- a/packages/plugins/content/spacer/src/createPlugin.tsx
+++ b/packages/plugins/content/spacer/src/createPlugin.tsx
@@ -39,6 +39,7 @@ const createPlugin: (
     <Spacer {...props} {...mergedSettings} />
   );
   return {
+    
     Component: WrappedComponent,
     name: 'ory/editor/core/content/spacer',
     version: '0.0.1',

--- a/packages/plugins/content/video/src/createPlugin.tsx
+++ b/packages/plugins/content/video/src/createPlugin.tsx
@@ -41,6 +41,7 @@ const createPlugin: (
     <Spacer {...props} {...mergedSettings} />
   );
   return {
+    
     Component: WrappedComponent,
     name: 'ory/editor/core/content/video',
     version: '0.0.1',

--- a/packages/plugins/createPluginMaterialUi/src/createContentPlugin.tsx
+++ b/packages/plugins/createPluginMaterialUi/src/createContentPlugin.tsx
@@ -33,6 +33,7 @@ function createPluginWithDef<T extends {}>({
       );
     },
     ...pluginSettings,
+    
   };
 }
 

--- a/packages/plugins/layout/background/src/createPlugin.tsx
+++ b/packages/plugins/layout/background/src/createPlugin.tsx
@@ -20,15 +20,13 @@
  *
  */
 import * as React from 'react';
-import { v4 } from 'uuid';
 
-import { LayoutPluginConfig } from '@react-page/core/lib/service/plugin/classes';
 import { BackgroundSettings } from './types/settings';
 import { BackgroundState } from './types/state';
 import { BackgroundProps } from './types/component';
 import BackgroundComponent from './Component';
 import { defaultSettings } from './default/settings';
-import { lazyLoad } from '@react-page/core';
+import { LayoutPluginConfig, lazyLoad } from '@react-page/core';
 
 const Icon = lazyLoad(() => import('@material-ui/icons/CropLandscape'));
 
@@ -38,6 +36,7 @@ const createPlugin = (settings: BackgroundSettings) => {
     Component: (props: BackgroundProps) => (
       <BackgroundComponent {...props} {...mergedSettings} />
     ),
+
     name: 'ory/editor/core/layout/background',
     version: '0.0.1',
 
@@ -47,23 +46,7 @@ const createPlugin = (settings: BackgroundSettings) => {
 
     createInitialChildren:
       settings.getInitialChildren ||
-      (() => ({
-        id: v4(),
-        rows: [
-          {
-            id: v4(),
-            cells: [
-              {
-                content: {
-                  plugin: settings.defaultPlugin,
-                  state: settings.defaultPlugin.createInitialState(),
-                },
-                id: v4(),
-              },
-            ],
-          },
-        ],
-      })),
+      (() => [[{ content: { plugin: settings.defaultPlugin } }]]),
 
     handleFocusNextHotKey: () => Promise.reject(),
     handleFocusPreviousHotKey: () => Promise.reject(),

--- a/packages/plugins/layout/background/src/types/settings.ts
+++ b/packages/plugins/layout/background/src/types/settings.ts
@@ -1,6 +1,6 @@
 import { BackgroundRendererProps } from './renderer';
 import { BackgroundControlsProps } from './controls';
-import { ContentPluginConfig } from '@react-page/core/lib/service/plugin/classes';
+import { InitialChildrenDef, ContentPluginConfig } from '@react-page/core';
 import { RGBColor } from '@react-page/ui/lib/ColorPicker/types';
 import { ImageUploadType } from '@react-page/ui/lib/ImageUpload/types';
 import { ModeEnum } from './ModeEnum';
@@ -12,7 +12,7 @@ export type BackgroundSettings = {
   defaultPlugin: ContentPluginConfig;
   enabledModes?: ModeEnum;
   // tslint:disable-next-line:no-any
-  getInitialChildren?: () => any;
+  getInitialChildren?: () => InitialChildrenDef;
   defaultBackgroundColor?: RGBColor;
   defaultGradientColor?: RGBColor;
   defaultGradientSecondaryColor?: RGBColor;

--- a/packages/ui/src/Toolbar/index.tsx
+++ b/packages/ui/src/Toolbar/index.tsx
@@ -31,12 +31,13 @@ import ListSubheader from '@material-ui/core/ListSubheader';
 import TextField from '@material-ui/core/TextField';
 import {
   LayoutPlugin,
-  ContentPlugin
-} from '@react-page/core/lib/service/plugin/classes';
+  ContentPlugin,
+  Plugin,
+  sanitizeInitialChildren
+} from '@react-page/core';
 import Item from './Item/index';
 
 import { useEditor } from './../Provider/index';
-import { Plugin } from '@react-page/core/lib/service/plugin/classes';
 
 export interface Translations {
   noPluginFoundContent: string | JSX.Element;
@@ -194,7 +195,9 @@ class Raw extends React.Component<Props, RawState> {
           >
             {layout.map((plugin: LayoutPlugin, k: Number) => {
               const initialState = plugin.createInitialState();
-              const children = plugin.createInitialChildren();
+              const children = sanitizeInitialChildren(
+                plugin.createInitialChildren()
+              );
 
               return (
                 <Item


### PR DESCRIPTION
createInitialChildren on layoutplugins now can return a more simple
definition: an Array of Array of Cells, where a cell is in its simplest form an object:
```
{
    content: {plugin: yourContentPlugin}
}
```

or another layout plugin:

```
{
    layout: {plugin: yourLayoutPlugin}
}
```