### PR TITLE
Feat/qualitiy of life improvements for editors

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "lint:watch": "npm-run-all watch:ts -- -c \"npm-run-all lint\"",
     "prettier": " prettier-tslint fix \"packages/**/src/**/*.(ts|tsx)\"",
     "publish": "lerna publish",
-    "start": "npm-run-all -p build:watch start:examples",
+    "start": "TSC_WATCHFILE=UseFsEventsWithFallbackDynamicPolling npm-run-all -p build:watch start:examples",
     "start:examples": "cross-env NODE_ENV=development lerna run start --stream",
     "test": "cross-env NODE_ENV=test jest --coverage",
     "test:watch": "cross-env NODE_ENV=test jest --watch",

--- a/packages/core/src/actions/cell/insert.ts
+++ b/packages/core/src/actions/cell/insert.ts
@@ -82,13 +82,14 @@ const insert = (type: string) => (
   return dispatch => {
     dispatch(insertAction);
     // FIXME: checking if an item is new or just moved around is a bit awkward
-    const isNew = !item.id;
+    const isNew = !item.id || (item.rows && !item.levels);
+
     if (isNew) {
       dispatch(editMode());
-      setTimeout(() => {
-        dispatch(focusCell(insertAction.ids.item)());
-      }, 300);
     }
+    setTimeout(() => {
+      dispatch(focusCell(insertAction.ids.item)());
+    }, 300);
   };
 };
 

--- a/packages/core/src/components/Cell/Content/index.tsx
+++ b/packages/core/src/components/Cell/Content/index.tsx
@@ -39,6 +39,7 @@ import {
 
 import { ComponetizedCell } from '../../../types/editable';
 import { ContentPluginProps } from '../../../service/plugin/classes';
+import scollIntoViewWithOffset from '../utils/scollIntoViewWithOffset';
 
 // TODO clean me up #157
 class Content extends React.PureComponent<ComponetizedCell> {
@@ -92,7 +93,12 @@ class Content extends React.PureComponent<ComponetizedCell> {
     if (!was && is) {
       // We need this because otherwise we lose hotkey focus on elements like spoilers.
       // This could probably be solved in an easier way by listening to window.document?
+
       handleFocus(pass, focusSource, this.ref);
+      // scroll to the plugin
+      if (this.ref) {
+        scollIntoViewWithOffset(this.ref, 100);
+      }
     } else if (was && !is) {
       handleBlur(pass);
     }

--- a/packages/core/src/components/Cell/Layout/index.tsx
+++ b/packages/core/src/components/Cell/Layout/index.tsx
@@ -35,6 +35,7 @@ import { isEditMode, isPreviewMode } from '../../../selector/display';
 
 import { ComponetizedCell } from '../../../types/editable';
 import { LayoutPluginProps } from '../../../service/plugin/classes';
+import scollIntoViewWithOffset from '../utils/scollIntoViewWithOffset';
 
 // TODO clean me up #157
 class Layout extends React.PureComponent<ComponetizedCell> {
@@ -89,6 +90,9 @@ class Layout extends React.PureComponent<ComponetizedCell> {
       // We need this because otherwise we lose hotkey focus on elements like spoilers.
       // This could probably be solved in an easier way by listening to window.document?
       handleFocus(pass, focusSource, this.ref);
+      if (this.ref) {
+        scollIntoViewWithOffset(this.ref, 100);
+      }
     } else if (was && !is) {
       handleBlur(pass);
     }

--- a/packages/core/src/components/Cell/index.css
+++ b/packages/core/src/components/Cell/index.css
@@ -39,8 +39,7 @@
 }
 
 .ory-cell-focused {
-  /* box-shadow: 0 0 5px rgb(81, 203, 238); */
-  /* outline: 1px solid rgb(81, 203, 238); */
+  box-shadow: 0 0 1000px rgba(0, 0, 0, 0.5);
 }
 
 .ory-cell {

--- a/packages/core/src/components/Cell/utils/scollIntoViewWithOffset.ts
+++ b/packages/core/src/components/Cell/utils/scollIntoViewWithOffset.ts
@@ -1,0 +1,14 @@
+export default (element: HTMLElement, offset = 0) => {
+  if (!element) {
+    return;
+  }
+  const bodyRect = document.body.getBoundingClientRect().top;
+  const elementRect = element.getBoundingClientRect().top;
+  const elementPosition = elementRect - bodyRect;
+  const offsetPosition = elementPosition - offset;
+
+  window.scrollTo({
+    top: offsetPosition,
+    behavior: 'smooth',
+  });
+};

--- a/packages/core/src/components/Cell/utils/scollIntoViewWithOffset.ts
+++ b/packages/core/src/components/Cell/utils/scollIntoViewWithOffset.ts
@@ -1,4 +1,8 @@
-export default (element: HTMLElement, offset = 0) => {
+export default (
+  element: HTMLElement,
+  offset = 0,
+  behavior: ScrollBehavior = 'smooth'
+) => {
   if (!element) {
     return;
   }
@@ -9,6 +13,6 @@ export default (element: HTMLElement, offset = 0) => {
 
   window.scrollTo({
     top: offsetPosition,
-    behavior: 'smooth',
+    behavior,
   });
 };

--- a/packages/core/src/components/Editable/Inner/index.tsx
+++ b/packages/core/src/components/Editable/Inner/index.tsx
@@ -19,7 +19,7 @@
  * @author Aeneas Rekkas <aeneas+oss@aeneas.io>
  *
  */
-
+import throttle from 'lodash.throttle';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
@@ -32,21 +32,64 @@ import { blurAllCells, createFallbackCell } from '../../../actions/cell';
 import { enableGlobalBlurring, disableGlobalBlurring } from './blur';
 
 import { EditableComponentState } from '../../../types/editable';
+import { RootState } from '../../../selector';
+import scollIntoViewWithOffset from '../../../components/Cell/utils/scollIntoViewWithOffset';
+function isElementInViewport(el: HTMLDivElement) {
+  const rect = el.getBoundingClientRect();
 
+  return (
+    rect.top >= 0 &&
+    rect.left >= 0 &&
+    rect.bottom <=
+      (window.innerHeight ||
+        document.documentElement.clientHeight) /*or $(window).height() */ &&
+    rect.right <=
+      (window.innerWidth ||
+        document.documentElement.clientWidth) /*or $(window).width() */
+  );
+}
 class Inner extends React.PureComponent<EditableComponentState> {
+  ref = React.createRef<HTMLDivElement>();
+  firstElementInViewport = null;
+
+  onScroll = throttle(() => {
+    if (this.ref.current) {
+      const firstInViewport: HTMLDivElement = Array.prototype.find.call(
+        this.ref.current.getElementsByClassName('ory-cell'),
+        (cell: HTMLDivElement) => isElementInViewport(cell)
+      );
+      if (firstInViewport) {
+        this.firstElementInViewport = {
+          el: firstInViewport,
+          topOffset: firstInViewport.getBoundingClientRect().top,
+        };
+      } else {
+        this.firstElementInViewport = null;
+      }
+    }
+  }, 600);
   componentDidMount() {
     enableGlobalBlurring(this.props.blurAllCells);
     this.createFallbackCell();
+    window.addEventListener('scroll', this.onScroll);
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(oldProps: EditableComponentState) {
     this.createFallbackCell();
+    if (oldProps.displayMode !== this.props.displayMode) {
+      if (this.firstElementInViewport) {
+        let { el, topOffset } = this.firstElementInViewport;
+        setTimeout(() => {
+          scollIntoViewWithOffset(el, topOffset, 'auto');
+        }, 0);
+      }
+    }
   }
 
   componentWillUnmount() {
     disableGlobalBlurring(this.props.blurAllCells);
+    window.removeEventListener('scroll', this.onScroll);
   }
-
   createFallbackCell = () => {
     const { node, defaultPlugin, id } = this.props;
     if (!node) {
@@ -67,7 +110,7 @@ class Inner extends React.PureComponent<EditableComponentState> {
 
     const { cells = [] } = node;
     return (
-      <div className="ory-editable ory-prevent-blur">
+      <div ref={this.ref} className="ory-editable ory-prevent-blur">
         {cells.map((c: string) => (
           <Cell
             rowWidth={containerWidth}
@@ -83,7 +126,16 @@ class Inner extends React.PureComponent<EditableComponentState> {
   }
 }
 
-const mapStateToProps = createStructuredSelector({ node: purifiedEditable });
+export const displayMode = ({
+  reactPage: {
+    display: { mode },
+  },
+}: RootState): string => mode;
+
+const mapStateToProps = createStructuredSelector({
+  node: purifiedEditable,
+  displayMode,
+});
 
 const mapDispatchToProps = { blurAllCells, createFallbackCell };
 

--- a/packages/core/src/types/editable.ts
+++ b/packages/core/src/types/editable.ts
@@ -120,6 +120,7 @@ export type ComponetizedCell = {
   resizeCell(id: string): void;
   focusCell(props: { source?: string }): void;
   blurCell(id: string): void;
+
   blurAllCells(): void;
   updateCellContent(state: Object): void;
   updateCellLayout(state: Object): void;
@@ -216,6 +217,7 @@ export type EditableComponentState = {
   isEditMode: boolean;
   isLayoutMode: boolean;
   isPreviewMode: boolean;
+  displayMode: string;
   defaultPlugin: ContentPluginConfig;
 
   blurAllCells(): void;

--- a/packages/plugins/content/html5-video/src/createPlugin.tsx
+++ b/packages/plugins/content/html5-video/src/createPlugin.tsx
@@ -31,9 +31,7 @@ import { Html5VideoSettings } from './types/settings';
 import { Html5VideoProps } from './types/component';
 import { Html5VideoState } from './types/state';
 import { defaultSettings } from './default/settings';
-import { lazyLoad } from '@react-page/core';
 
-const Icon = lazyLoad(() => import('@material-ui/icons/PlayArrow'));
 export type Props = ContentPluginProps;
 
 const rejectPromise: (e: Event, props: Props) => Promise<void> = (
@@ -49,13 +47,12 @@ const createPlugin: (
     <Html5Video {...props} {...mergedSettings} />
   );
   return {
-    
     Component: WrappedComponent,
     name: 'ory/sites/plugin/content/html5-video',
     version: '0.0.1',
     text: mergedSettings.translations.pluginName,
     description: mergedSettings.translations.pluginDescription,
-    IconComponent: <Icon />,
+    IconComponent: mergedSettings.IconComponent,
     handleFocusNextHotKey: rejectPromise,
     handleFocusPreviousHotKey: rejectPromise,
     createInitialState: () => ({

--- a/packages/plugins/content/html5-video/src/default/settings.tsx
+++ b/packages/plugins/content/html5-video/src/default/settings.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
 import { Html5VideoSettings } from '../types/settings';
+import { lazyLoad } from '@react-page/core';
+
+const PlayArrow = lazyLoad(() => import('@material-ui/icons/PlayArrow'));
 
 export const defaultTranslations = {
   pluginName: 'HTML 5 Video',
@@ -9,7 +12,8 @@ export const defaultTranslations = {
 };
 
 export const defaultSettings: Html5VideoSettings = {
-  Controls: () => <> Controls for this plugin were not provided</> ,
+  Controls: () => <> Controls for this plugin were not provided</>,
   Renderer: () => <>Renderer; for this plugin was not provided </>,
   translations: defaultTranslations,
+  IconComponent: <PlayArrow />,
 };

--- a/packages/plugins/content/html5-video/src/types/settings.ts
+++ b/packages/plugins/content/html5-video/src/types/settings.ts
@@ -6,4 +6,5 @@ export interface Html5VideoSettings {
   Renderer: React.ComponentType<Html5VideoRendererProps>;
   Controls: React.ComponentType<Html5VideoControlsProps>;
   translations?: Translations;
+  IconComponent?: React.ReactNode;
 }

--- a/packages/plugins/content/image/src/Controls/ImageDefaultControls.tsx
+++ b/packages/plugins/content/image/src/Controls/ImageDefaultControls.tsx
@@ -16,11 +16,13 @@ const ImageDefaultControls: React.SFC<ImageControlsProps> = props => {
     focused,
     remove,
   } = props;
+
   return (
     <div>
       <Renderer {...props} imagePreview={props.imagePreview} />
       {!readOnly && focused && (
         <BottomToolbar
+          icon={props.IconComponent}
           open={props.focused}
           title={props.translations.pluginName}
           onDelete={remove}

--- a/packages/plugins/content/image/src/createPlugin.tsx
+++ b/packages/plugins/content/image/src/createPlugin.tsx
@@ -29,9 +29,6 @@ import {
 import { ImageState } from './types/state';
 import { ImageSettings } from './types/settings';
 import { defaultSettings } from './default/settings';
-import { lazyLoad } from '@react-page/core';
-
-const Panorama = lazyLoad(() => import('@material-ui/icons/Panorama'));
 
 const createPlugin = (
   settings?: ImageSettings
@@ -41,10 +38,10 @@ const createPlugin = (
     Component: (props: ContentPluginProps<ImageState>) => (
       <Component {...props} {...mergedSettings} />
     ),
-    
+
     name: 'ory/editor/core/content/image',
     version: '0.0.1',
-    IconComponent: <Panorama />,
+    IconComponent: mergedSettings.IconComponent,
     text: mergedSettings.translations.pluginName,
     isInlineable: true,
     description: mergedSettings.translations.pluginDescription,

--- a/packages/plugins/content/image/src/default/settings.tsx
+++ b/packages/plugins/content/image/src/default/settings.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { ImageSettings } from '../types/settings';
+import { lazyLoad } from '@react-page/core';
+const Panorama = lazyLoad(() => import('@material-ui/icons/Panorama'));
 
 export const defaultTranslations = {
   pluginName: 'Image',
@@ -14,7 +16,8 @@ export const defaultTranslations = {
 };
 
 export const defaultSettings: ImageSettings = {
-  Controls: () => <> Controls for this plugin were not provided</> ,
+  Controls: () => <> Controls for this plugin were not provided</>,
   Renderer: () => <>Renderer; for this plugin was not provided </>,
   translations: defaultTranslations,
+  IconComponent: <Panorama />,
 };

--- a/packages/plugins/content/image/src/types/settings.ts
+++ b/packages/plugins/content/image/src/types/settings.ts
@@ -8,4 +8,5 @@ export type ImageSettings = {
   Renderer: React.ComponentType<ImageRendererProps>;
   Controls: React.ComponentType<ImageControlsProps>;
   translations?: Translations;
+  IconComponent?: React.ReactNode;
 };

--- a/packages/plugins/content/slate/src/Controls/index.tsx
+++ b/packages/plugins/content/slate/src/Controls/index.tsx
@@ -243,7 +243,7 @@ class Slate extends React.PureComponent<SlateProps, SlateState> {
         />
 
         {!readOnly ? (
-          <BottomToolbar open={showBottomToolbar} dark={true}>
+          <BottomToolbar open={showBottomToolbar} dark={true} hideHeader={true}>
             <ToolbarButtons
               {...this.props}
               translations={this.props.translations}

--- a/packages/plugins/content/slate/src/Controls/index.tsx
+++ b/packages/plugins/content/slate/src/Controls/index.tsx
@@ -90,7 +90,7 @@ const ToolbarButtons = ({
   </div>
 );
 
-class Slate extends React.Component<SlateProps, SlateState> {
+class Slate extends React.PureComponent<SlateProps, SlateState> {
   private toolbar: React.RefObject<HTMLDivElement>;
   private editor: React.RefObject<CoreEditor>;
   private flushStateDebounced: (() => void) & Cancelable;
@@ -204,8 +204,8 @@ class Slate extends React.Component<SlateProps, SlateState> {
     const showBottomToolbar = Boolean(focused);
 
     return (
-      <div>
-        {focused && (
+      <>
+        {!readOnly && focused && (
           <Portal>
             {/* ory-prevent-blur is required to prevent global blurring */}
 
@@ -252,7 +252,7 @@ class Slate extends React.Component<SlateProps, SlateState> {
             />
           </BottomToolbar>
         ) : null}
-      </div>
+      </>
     );
   }
 }

--- a/packages/plugins/content/slate/src/index.tsx
+++ b/packages/plugins/content/slate/src/index.tsx
@@ -92,9 +92,11 @@ const defaultConfig: DefaultSlateDefinition = {
   allowInlineNeighbours: true,
 };
 
-type CustomizeFunction = (def: DefaultSlateDefinition) => SlateDefinition;
+export type SlateCustomizeFunction = (
+  def: DefaultSlateDefinition
+) => SlateDefinition;
 export default (
-  customize?: CustomizeFunction
+  customize?: SlateCustomizeFunction
 ): ContentPluginConfig<SlateState> => {
   const settings = customize ? customize(defaultConfig) : defaultConfig;
   const createInitialState = () =>
@@ -110,7 +112,6 @@ export default (
   });
 
   return {
-    
     Component: (props: SlateProps) => (
       <Component
         Renderer={settings.Renderer}

--- a/packages/plugins/content/video/src/Controls/VideoDefaultControls.tsx
+++ b/packages/plugins/content/video/src/Controls/VideoDefaultControls.tsx
@@ -40,6 +40,7 @@ const Form: React.SFC<VideoControlsProps> = props => {
     <BottomToolbar
       open={focused}
       title={props.translations.pluginName}
+      icon={props.IconComponent}
       onDelete={remove}
     >
       <TextField

--- a/packages/plugins/content/video/src/createPlugin.tsx
+++ b/packages/plugins/content/video/src/createPlugin.tsx
@@ -29,9 +29,6 @@ import { VideoSettings } from './types/settings';
 import { VideoProps } from './types/component';
 import { VideoState } from './types/state';
 import { defaultSettings } from './default/settings';
-import { lazyLoad } from '@react-page/core';
-
-const PlayArrow = lazyLoad(() => import('@material-ui/icons/PlayArrow'));
 
 const createPlugin: (
   settings: VideoSettings
@@ -41,11 +38,10 @@ const createPlugin: (
     <Spacer {...props} {...mergedSettings} />
   );
   return {
-    
     Component: WrappedComponent,
     name: 'ory/editor/core/content/video',
     version: '0.0.1',
-    IconComponent: <PlayArrow />,
+    IconComponent: mergedSettings.IconComponent,
     text: mergedSettings.translations.pluginName,
     description: mergedSettings.translations.pluginDescription,
     isInlineable: true,

--- a/packages/plugins/content/video/src/default/settings.tsx
+++ b/packages/plugins/content/video/src/default/settings.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
 import { VideoSettings } from '../types/settings';
+import { lazyLoad } from '@react-page/core';
+
+const PlayArrow = lazyLoad(() => import('@material-ui/icons/PlayArrow'));
 
 export const defaultTranslations = {
   pluginName: 'Video',
@@ -9,7 +12,8 @@ export const defaultTranslations = {
 };
 
 export const defaultSettings: VideoSettings = {
-  Controls: () => <> Controls for this plugin were not provided</> ,
+  Controls: () => <> Controls for this plugin were not provided</>,
   Renderer: () => <>Renderer; for this plugin was not provided </>,
   translations: defaultTranslations,
+  IconComponent: <PlayArrow />,
 };

--- a/packages/plugins/content/video/src/types/settings.ts
+++ b/packages/plugins/content/video/src/types/settings.ts
@@ -8,4 +8,5 @@ export interface VideoSettings {
   placeholder?: string;
   label?: string;
   translations?: Translations;
+  IconComponent?: React.ReactNode;
 }

--- a/packages/plugins/createPluginMaterialUi/src/Controls/index.tsx
+++ b/packages/plugins/createPluginMaterialUi/src/Controls/index.tsx
@@ -34,7 +34,12 @@ function Controls<T>(props: ControlProps<T>) {
     <>
       <Renderer {...props} state={preview || state} />
 
-      <BottomToolbar open={focused} title={props.text} onDelete={remove}>
+      <BottomToolbar
+        open={focused}
+        title={props.text}
+        onDelete={remove}
+        icon={props.IconComponent}
+      >
         <div style={{ marginBottom: 12 }}>
           <AutoForm
             model={preview || state}

--- a/packages/plugins/createPluginMaterialUi/src/Controls/index.tsx
+++ b/packages/plugins/createPluginMaterialUi/src/Controls/index.tsx
@@ -35,14 +35,16 @@ function Controls<T>(props: ControlProps<T>) {
       <Renderer {...props} state={preview || state} />
 
       <BottomToolbar open={focused} title={props.text} onDelete={remove}>
-        <AutoForm
-          model={preview || state}
-          autosave={true}
-          schema={makeUniformsSchema<T>(schema)}
-          onSubmit={onSubmit}
-        >
-          <AutoFields />
-        </AutoForm>
+        <div style={{ marginBottom: 12 }}>
+          <AutoForm
+            model={preview || state}
+            autosave={true}
+            schema={makeUniformsSchema<T>(schema)}
+            onSubmit={onSubmit}
+          >
+            <AutoFields />
+          </AutoForm>
+        </div>
       </BottomToolbar>
     </>
   );

--- a/packages/plugins/createPluginMaterialUi/src/Controls/index.tsx
+++ b/packages/plugins/createPluginMaterialUi/src/Controls/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { Fragment, useState, useCallback } from 'react';
 import { ControlProps } from '../types';
 
 import {
@@ -40,14 +40,22 @@ function Controls<T>(props: ControlProps<T>) {
         onDelete={remove}
         icon={props.IconComponent}
       >
-        <div style={{ marginBottom: 12 }}>
+        <div style={{ marginBottom: 24 }}>
           <AutoForm
             model={preview || state}
             autosave={true}
             schema={makeUniformsSchema<T>(schema)}
             onSubmit={onSubmit}
           >
-            <AutoFields />
+            <div
+              style={{
+                columnCount: 2,
+                columnRule: '1px solid #E0E0E0',
+                columnGap: 48,
+              }}
+            >
+              <AutoFields element={Fragment} />
+            </div>
           </AutoForm>
         </div>
       </BottomToolbar>

--- a/packages/plugins/createPluginMaterialUi/src/index.tsx
+++ b/packages/plugins/createPluginMaterialUi/src/index.tsx
@@ -1,10 +1,11 @@
 import createContentPlugin from './createContentPlugin';
 import createLayoutPlugin from './createLayoutPlugin';
 import makeUniformsSchema from './utils/makeUniformsSchema';
-import { JsonSchema } from './types/jsonSchema';
+import { JsonSchema, JsonSchemaProperty } from './types/jsonSchema';
 export {
   createContentPlugin,
   createLayoutPlugin,
   makeUniformsSchema,
-  JsonSchema
+  JsonSchema,
+  JsonSchemaProperty
 };

--- a/packages/plugins/createPluginMaterialUi/src/types/jsonSchema.ts
+++ b/packages/plugins/createPluginMaterialUi/src/types/jsonSchema.ts
@@ -23,7 +23,7 @@ type NumberProperty = {
 } & CommonPropertyProps;
 
 type ObjectProperty<T extends object> = JsonSchema<T> & CommonPropertyProps;
-type Property<T> = T extends object
+export type JsonSchemaProperty<T> = T extends object
   ? ObjectProperty<T>
   : T extends string
   ? StringProperty
@@ -36,7 +36,7 @@ type Property<T> = T extends object
 export type JsonSchema<T extends object> = {
   title?: string;
   type: 'object';
-  properties: { [K in keyof T]-?: Property<T[K]> };
+  properties: { [K in keyof T]-?: JsonSchemaProperty<T[K]> };
   // required: string[];
   /** union to tuple conversion is expensive, we do a poor mans version here */
   required: Array<keyof T>;

--- a/packages/plugins/layout/background/src/Controls/BackgroundDefaultControls.tsx
+++ b/packages/plugins/layout/background/src/Controls/BackgroundDefaultControls.tsx
@@ -51,7 +51,11 @@ class BackgroundDefaultControls extends React.Component<
         ? this.props.lightenPreview
         : lighten;
     return (
-      <BottomToolbar open={focused}>
+      <BottomToolbar
+        open={focused}
+        title={this.props.translations.pluginName}
+        icon={this.props.IconComponent}
+      >
         <Tabs
           value={this.state.mode}
           onChange={this.handleChangeMode}

--- a/packages/ui/src/BottomToolbar/index.tsx
+++ b/packages/ui/src/BottomToolbar/index.tsx
@@ -89,43 +89,47 @@ const BottomToolbar: React.SFC<BottomToolbarProps> = ({
           maxWidth: 'calc(100vw - 220px)',
         }}
       >
-        {title || onDelete ? (
-          <>
-            <Grid container={true} direction="row" alignItems="center">
-              <Grid item={true}>
-                <Avatar
-                  children={icon || (title ? title[0] : '')}
-                  style={{
-                    marginRight: 16,
-                  }}
-                />
-              </Grid>
-              <Grid item={true}>
-                <Typography variant="subtitle1">{title}</Typography>
-              </Grid>
-              {onDelete ? (
-                <Grid item={true} style={{ marginLeft: 'auto' }}>
-                  <IconButton
-                    onClick={onDelete}
-                    aria-label="delete"
-                    color="secondary"
-                  >
-                    <Delete fontSize="small" />
-                  </IconButton>
-                </Grid>
-              ) : null}
-            </Grid>
-
-            <Divider
+        <Grid container={true} direction="row" alignItems="center">
+          <Grid item={true}>
+            <Avatar
+              children={icon || (title ? title[0] : '')}
               style={{
-                marginLeft: -24,
-                marginRight: -24,
-                marginTop: 12,
-                marginBottom: 12,
+                marginRight: 16,
               }}
             />
-          </>
-        ) : null}
+          </Grid>
+          <Grid item={true}>
+            <Typography variant="subtitle1">{title}</Typography>
+          </Grid>
+          {onDelete ? (
+            <Grid item={true} style={{ marginLeft: 'auto' }}>
+              <IconButton
+                onClick={onDelete}
+                aria-label="delete"
+                color="secondary"
+              >
+                <Delete fontSize="small" />
+              </IconButton>
+              <IconButton
+                onClick={onDelete}
+                aria-label="delete"
+                color="secondary"
+              >
+                <Delete fontSize="small" />
+              </IconButton>
+            </Grid>
+          ) : null}
+        </Grid>
+
+        <Divider
+          style={{
+            marginLeft: -24,
+            marginRight: -24,
+            marginTop: 12,
+            marginBottom: 12,
+          }}
+        />
+
         {children}
       </div>
     </Drawer>

--- a/packages/ui/src/BottomToolbar/index.tsx
+++ b/packages/ui/src/BottomToolbar/index.tsx
@@ -86,6 +86,7 @@ const BottomToolbar: React.SFC<BottomToolbarProps> = ({
           boxShadow: '0px 1px 8px -1px rgba(0,0,0,0.4)',
           position: 'relative',
           minWidth: '50vw',
+          maxWidth: 'calc(100vw - 220px)',
         }}
       >
         {title || onDelete ? (

--- a/packages/ui/src/BottomToolbar/index.tsx
+++ b/packages/ui/src/BottomToolbar/index.tsx
@@ -37,6 +37,7 @@ const bright = 'rgba(255,255,255, 0.98)';
 const brightBorder = 'rgba(0, 0, 0, 0.12)';
 export interface BottomToolbarProps {
   open?: boolean;
+  hideHeader?: boolean;
   children?: Object;
   className?: string;
   dark: boolean;
@@ -52,7 +53,7 @@ const BottomToolbar: React.SFC<BottomToolbarProps> = ({
   children,
   className,
   dark = false,
-
+  hideHeader = false,
   anchor = 'bottom',
   onDelete = null,
   title,
@@ -89,46 +90,50 @@ const BottomToolbar: React.SFC<BottomToolbarProps> = ({
           maxWidth: 'calc(100vw - 220px)',
         }}
       >
-        <Grid container={true} direction="row" alignItems="center">
-          <Grid item={true}>
-            <Avatar
-              children={icon || (title ? title[0] : '')}
+        {!hideHeader ? (
+          <>
+            <Grid container={true} direction="row" alignItems="center">
+              <Grid item={true}>
+                <Avatar
+                  children={icon || (title ? title[0] : '')}
+                  style={{
+                    marginRight: 16,
+                  }}
+                />
+              </Grid>
+              <Grid item={true}>
+                <Typography variant="subtitle1">{title}</Typography>
+              </Grid>
+              {onDelete ? (
+                <Grid item={true} style={{ marginLeft: 'auto' }}>
+                  <IconButton
+                    onClick={onDelete}
+                    aria-label="delete"
+                    color="secondary"
+                  >
+                    <Delete fontSize="small" />
+                  </IconButton>
+                  <IconButton
+                    onClick={onDelete}
+                    aria-label="delete"
+                    color="secondary"
+                  >
+                    <Delete fontSize="small" />
+                  </IconButton>
+                </Grid>
+              ) : null}
+            </Grid>
+
+            <Divider
               style={{
-                marginRight: 16,
+                marginLeft: -24,
+                marginRight: -24,
+                marginTop: 12,
+                marginBottom: 12,
               }}
             />
-          </Grid>
-          <Grid item={true}>
-            <Typography variant="subtitle1">{title}</Typography>
-          </Grid>
-          {onDelete ? (
-            <Grid item={true} style={{ marginLeft: 'auto' }}>
-              <IconButton
-                onClick={onDelete}
-                aria-label="delete"
-                color="secondary"
-              >
-                <Delete fontSize="small" />
-              </IconButton>
-              <IconButton
-                onClick={onDelete}
-                aria-label="delete"
-                color="secondary"
-              >
-                <Delete fontSize="small" />
-              </IconButton>
-            </Grid>
-          ) : null}
-        </Grid>
-
-        <Divider
-          style={{
-            marginLeft: -24,
-            marginRight: -24,
-            marginTop: 12,
-            marginBottom: 12,
-          }}
-        />
+          </>
+        ) : null}
 
         {children}
       </div>

--- a/packages/ui/src/BottomToolbar/index.tsx
+++ b/packages/ui/src/BottomToolbar/index.tsx
@@ -71,14 +71,15 @@ const BottomToolbar: React.SFC<BottomToolbar> = ({
           borderRadius: '4px 4px 0 0',
           backgroundColor: dark ? darkBlack : bright,
           padding: '12px 24px',
+
           margin: 'auto',
-          boxShadow: '0px 1px 6px -1px rgba(0,0,0,0.2)',
+          boxShadow: '0px 1px 8px -1px rgba(0,0,0,0.4)',
           position: 'relative',
         }}
       >
         {title || onDelete ? (
           <>
-            <Typography>{title}</Typography>
+            <Typography variant="subtitle1">{title}</Typography>
             {onDelete ? (
               <IconButton
                 onClick={onDelete}

--- a/packages/ui/src/BottomToolbar/index.tsx
+++ b/packages/ui/src/BottomToolbar/index.tsx
@@ -24,29 +24,39 @@ import Drawer from '@material-ui/core/Drawer';
 import * as React from 'react';
 
 import ThemeProvider, { darkTheme } from '../ThemeProvider';
-import { Typography, Divider, IconButton } from '@material-ui/core';
+import {
+  Typography,
+  Divider,
+  IconButton,
+  Grid,
+  Avatar
+} from '@material-ui/core';
 
 const darkBlack = 'rgba(0, 0, 0, 0.87)';
 const bright = 'rgba(255,255,255, 0.98)';
 const brightBorder = 'rgba(0, 0, 0, 0.12)';
-export interface BottomToolbar {
+export interface BottomToolbarProps {
   open?: boolean;
   children?: Object;
   className?: string;
   dark: boolean;
   title?: string;
-  anchor?: 'top' | 'bottom';
+  anchor?: 'top' | 'bottom' | 'left' | 'right';
   onDelete?: () => void;
+  // tslint:disable-next-line:no-any
+  icon?: any;
 }
 
-const BottomToolbar: React.SFC<BottomToolbar> = ({
+const BottomToolbar: React.SFC<BottomToolbarProps> = ({
   open = false,
   children,
   className,
   dark = false,
+
   anchor = 'bottom',
   onDelete = null,
   title,
+  icon = null,
 }) => (
   <ThemeProvider theme={dark ? darkTheme : null}>
     <Drawer
@@ -75,23 +85,43 @@ const BottomToolbar: React.SFC<BottomToolbar> = ({
           margin: 'auto',
           boxShadow: '0px 1px 8px -1px rgba(0,0,0,0.4)',
           position: 'relative',
+          minWidth: '50vw',
         }}
       >
         {title || onDelete ? (
           <>
-            <Typography variant="subtitle1">{title}</Typography>
-            {onDelete ? (
-              <IconButton
-                onClick={onDelete}
-                aria-label="delete"
-                color="secondary"
-                style={{ position: 'absolute', top: 0, right: 0 }}
-              >
-                <Delete fontSize="small" />
-              </IconButton>
-            ) : null}
+            <Grid container={true} direction="row" alignItems="center">
+              <Grid item={true}>
+                <Avatar
+                  children={icon || (title ? title[0] : '')}
+                  style={{
+                    marginRight: 16,
+                  }}
+                />
+              </Grid>
+              <Grid item={true}>
+                <Typography variant="subtitle1">{title}</Typography>
+              </Grid>
+              {onDelete ? (
+                <Grid item={true} style={{ marginLeft: 'auto' }}>
+                  <IconButton
+                    onClick={onDelete}
+                    aria-label="delete"
+                    color="secondary"
+                  >
+                    <Delete fontSize="small" />
+                  </IconButton>
+                </Grid>
+              ) : null}
+            </Grid>
+
             <Divider
-              style={{ marginLeft: -24, marginRight: -24, marginBottom: 12 }}
+              style={{
+                marginLeft: -24,
+                marginRight: -24,
+                marginTop: 12,
+                marginBottom: 12,
+              }}
             />
           </>
         ) : null}

--- a/packages/ui/src/Toolbar/Item/index.tsx
+++ b/packages/ui/src/Toolbar/Item/index.tsx
@@ -69,7 +69,7 @@ class Item extends React.Component<ItemProps, ItemState> {
     return (
       <ListItem className="ory-toolbar-item">
         <Avatar
-          children={plugin.IconComponent}
+          children={plugin.IconComponent || plugin.text[0]}
           style={{
             marginRight: 16,
           }}

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -6,6 +6,7 @@ const Trash = loadable(() => import('./Trash/index'));
 const Toolbar = loadable(() => import('./Toolbar/index'));
 const DisplayModeToggle = loadable(() => import('./DisplayModeToggle/index'));
 const BottomToolbar = loadable(() => import('./BottomToolbar/index'));
+
 const ThemeProvider = loadable(() => import('./ThemeProvider/index'));
 const ImageUpload = loadable(() => import('./ImageUpload/index'));
 const ColorPicker = loadable(() => import('./ColorPicker/index'));


### PR DESCRIPTION
**feat: highlight active cells**

this was already there but commented out. I believe its useful to highight focused cells. And its easy to override with css, so i think it makes sense to have it by default

**feat: Bottom toolbar shows icon**

cleaner bottom toolbar layout with a bigger title and an icon

**feat: keep scroll position after changing mode by checking which element is first in viewport**

view might jump after changing the edit mode, which is annoying when adding a layout plugin and try to edit it afterwards. This change tries to keep the scroll position by looking at the first element in the viewport.  So even if changing mode will change the sizes of elements, it should restore the correct scroll position. It's not smooth, but it works in most cases now.

**feat: scroll to cell when focused**

i think this is handy and helps editors to find the elements they want to edit.

**feat: always focus cells after move** 

when dragging cells around, it will focus them after drop

**feat: also scroll layout cells into view when focused**

same change as above, but also for layout plugins


**feat: give button toolbar more whitespace on the bottom in form controls**

cosmetics. i think the bottom toolbar can still be improved though

**fix: whatch no longer works in dev**

yeah, i broke that, its fixed now