### PR TITLE
Don't use target es6 in es transpile to support IE11

### DIFF
--- a/packages/core/tsconfig-es.json
+++ b/packages/core/tsconfig-es.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "lib-es",
-    "target": "es6",
-    "module": "esNext"
+    "module": "esnext"
   }
 }

--- a/packages/plugins/content/divider/tsconfig-es.json
+++ b/packages/plugins/content/divider/tsconfig-es.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "lib-es",
-    "target": "es6",
-    "module": "esNext"
+    "module": "esnext"
   }
 }

--- a/packages/plugins/content/html5-video/tsconfig-es.json
+++ b/packages/plugins/content/html5-video/tsconfig-es.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "lib-es",
-    "target": "es6",
-    "module": "esNext"
+    "module": "esnext"
   }
 }

--- a/packages/plugins/content/image/tsconfig-es.json
+++ b/packages/plugins/content/image/tsconfig-es.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "lib-es",
-    "target": "es6",
-    "module": "esNext"
+    "module": "esnext"
   }
 }

--- a/packages/plugins/content/native/tsconfig-es.json
+++ b/packages/plugins/content/native/tsconfig-es.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "lib-es",
-    "target": "es6",
-    "module": "esNext"
+    "module": "esnext"
   }
 }

--- a/packages/plugins/content/slate/tsconfig-es.json
+++ b/packages/plugins/content/slate/tsconfig-es.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "lib-es",
-    "target": "es6",
-    "module": "esNext"
+    "module": "esnext"
   }
 }

--- a/packages/plugins/content/spacer/tsconfig-es.json
+++ b/packages/plugins/content/spacer/tsconfig-es.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "lib-es",
-    "target": "es6",
-    "module": "esNext"
+    "module": "esnext"
   }
 }

--- a/packages/plugins/content/video/tsconfig-es.json
+++ b/packages/plugins/content/video/tsconfig-es.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "lib-es",
-    "target": "es6",
-    "module": "esNext"
+    "module": "esnext"
   }
 }

--- a/packages/plugins/createPluginMaterialUi/tsconfig-es.json
+++ b/packages/plugins/createPluginMaterialUi/tsconfig-es.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "lib-es",
-    "target": "es6",
-    "module": "esNext"
+    "module": "esnext"
   }
 }

--- a/packages/plugins/layout/background/tsconfig-es.json
+++ b/packages/plugins/layout/background/tsconfig-es.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "lib-es",
-    "target": "es6",
-    "module": "esNext"
+    "module": "esnext"
   }
 }

--- a/packages/renderer/tsconfig-es.json
+++ b/packages/renderer/tsconfig-es.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "lib-es",
-    "target": "es6",
-    "module": "esNext"
+    "module": "esnext"
   }
 }

--- a/packages/ui/tsconfig-es.json
+++ b/packages/ui/tsconfig-es.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "lib-es",
-    "target": "es6",
-    "module": "esNext"
+    "module": "esnext"
   }
 }


### PR DESCRIPTION
## Proposed changes

ES target was transpiling with es6 features (like `const` and `=>`). This PR keeps the `import`s and `export`s, but transpile to es5 code (`var` and `function`)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules