### PR TITLE
Feat: new toolbar actions: clone and hide

### DIFF
--- a/examples/src/customLayoutPluginWithInitialState.tsx
+++ b/examples/src/customLayoutPluginWithInitialState.tsx
@@ -93,10 +93,16 @@ export default () =>
                   {
                     plugin: plugins.headings.h2,
                     children: ['Hello world'],
+                    data: {
+                      align: 'center',
+                    },
                   },
                   {
                     plugin: plugins.paragraphs.paragraph,
                     children: ['Another entry'],
+                    data: {
+                      align: 'center',
+                    },
                   },
                 ],
               })),

--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -20,6 +20,7 @@ if (
 // tslint:disable-next-line:no-any
 const KeepStateEditor = ({ value, ...props }: any) => {
   const [state, setState] = React.useState(value);
+  console.log(state);
   // here you would normally persist the state somewhere (e.g a database)
   // <Editor /> is stateful, so you don't nesseary have to keep the value updated
   // if you do, you have to guarantee that the value is referencially equal to what has been passed by `onChange`

--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -20,7 +20,7 @@ if (
 // tslint:disable-next-line:no-any
 const KeepStateEditor = ({ value, ...props }: any) => {
   const [state, setState] = React.useState(value);
-  console.log(state);
+
   // here you would normally persist the state somewhere (e.g a database)
   // <Editor /> is stateful, so you don't nesseary have to keep the value updated
   // if you do, you have to guarantee that the value is referencially equal to what has been passed by `onChange`

--- a/packages/core/src/actions/cell/core.ts
+++ b/packages/core/src/actions/cell/core.ts
@@ -21,12 +21,13 @@
  */
 
 import { Action } from 'redux';
-import { EditorState } from '../../types/editor';
 import uuid from 'uuid';
 import { NewIds } from '../../types/editable';
+import { EditorState } from '../../types/editor';
 import { generateIds } from '../helpers';
 
 export const CELL_UPDATE_CONTENT = 'CELL_UPDATE_CONTENT';
+export const CELL_UPDATE_IS_DRAFT = 'CELL_UPDATE_IS_DRAFT';
 export const CELL_UPDATE_LAYOUT = 'CELL_UPDATE_LAYOUT';
 export const CELL_REMOVE = 'CELL_REMOVE';
 export const CELL_RESIZE = 'CELL_RESIZE';
@@ -41,6 +42,12 @@ export interface UpdateCellContentAction extends Action {
   ts: Date;
   id: string;
   state: EditorState;
+}
+
+export interface UpdateCellIsDraftAction extends Action {
+  ts: Date;
+  id: string;
+  isDraft: boolean;
 }
 /**
  * An action creator for updating a cell's content data.
@@ -60,6 +67,27 @@ export const updateCellContent = (id: string) => (
   ts: new Date(),
   id,
   state,
+});
+
+/**
+ * An action creator for setting the cell's isDraft property
+ *
+ * @example
+ * // const store = redux.createStore()
+ * // const cell = { id: '1', ... }
+ * store.dispatch(updateCellContent(cell.id, { foo: 'bar' }))
+ *
+ * @param {string} id The id of the cell that should be updated
+ * @return {Action}
+ */
+export const updateCellIsDraft = (
+  id: string,
+  isDraft: boolean = false
+): UpdateCellIsDraftAction => ({
+  type: CELL_UPDATE_IS_DRAFT,
+  ts: new Date(),
+  id,
+  isDraft,
 });
 
 export interface UpdateCellLayoutAction extends Action {
@@ -246,4 +274,5 @@ export const coreActions = {
   removeCell,
   updateCellLayout,
   updateCellContent,
+  updateCellIsDraft,
 };

--- a/packages/core/src/actions/cell/insert.ts
+++ b/packages/core/src/actions/cell/insert.ts
@@ -19,11 +19,11 @@
  * @author Aeneas Rekkas <aeneas+oss@aeneas.io>
  *
  */
-import { Cell, NewIds } from '../../types/editable';
 import { Action } from 'redux';
-
-import { generateIds } from '../helpers';
+import { v4 } from 'uuid';
+import { Cell, NewIds } from '../../types/editable';
 import { editMode } from '../display';
+import { generateIds } from '../helpers';
 import { focusCell } from './core';
 
 export const CELL_INSERT_ABOVE = 'CELL_INSERT_ABOVE';
@@ -32,6 +32,7 @@ export const CELL_INSERT_LEFT_OF = 'CELL_INSERT_LEFT_OF';
 export const CELL_INSERT_RIGHT_OF = 'CELL_INSERT_RIGHT_OF';
 export const CELL_INSERT_INLINE_LEFT = 'CELL_INSERT_INLINE_LEFT';
 export const CELL_INSERT_INLINE_RIGHT = 'CELL_INSERT_INLINE_RIGHT';
+export const CELL_DUPLICATE = 'CELL_DUPLICATE';
 
 export interface InsertAction extends Action {
   ts: Date;
@@ -48,6 +49,7 @@ const insert = (type: string) => (
   ids: NewIds = null
 ) => {
   let l = level;
+  console.log(item, level);
   switch (type) {
     case CELL_INSERT_ABOVE:
     case CELL_INSERT_BELOW: {
@@ -123,6 +125,23 @@ export const insertCellLeftInline = insert(CELL_INSERT_INLINE_LEFT);
  */
 export const insertCellRightInline = insert(CELL_INSERT_INLINE_RIGHT);
 
+// set new ids recursivly
+const newIds = ({ id, ...item }: Partial<Cell>) => {
+  return {
+    ...item,
+    id: v4(),
+    rows: item.rows
+      ? item.rows.map(row => ({
+          ...row,
+          id: v4(),
+          cells: row.cells ? row.cells.map(newIds) : undefined,
+        }))
+      : undefined,
+  };
+};
+export const duplicateCell = item => dispatch =>
+  dispatch(insertCellBelow(newIds(item), item));
+
 export const insertActions = {
   insertCellRightInline,
   insertCellLeftInline,
@@ -130,5 +149,6 @@ export const insertActions = {
   insertCellRightOf,
   insertCellAbove,
   insertCellBelow,
+  duplicateCell,
   insert,
 };

--- a/packages/core/src/actions/cell/insert.ts
+++ b/packages/core/src/actions/cell/insert.ts
@@ -49,7 +49,7 @@ const insert = (type: string) => (
   ids: NewIds = null
 ) => {
   let l = level;
-  console.log(item, level);
+
   switch (type) {
     case CELL_INSERT_ABOVE:
     case CELL_INSERT_BELOW: {

--- a/packages/core/src/components/Cell/index.css
+++ b/packages/core/src/components/Cell/index.css
@@ -37,9 +37,14 @@
   float: none;
   width: 100%;
 }
+.ory-cell-is-draft {
+  opacity: 0.3;
+  outline: 1px dashed black;
+}
 
 .ory-cell-focused {
   box-shadow: 0 0 1000px rgba(0, 0, 0, 0.5);
+  opacity: 1;
 }
 
 .ory-cell {

--- a/packages/core/src/components/Cell/index.tsx
+++ b/packages/core/src/components/Cell/index.tsx
@@ -20,43 +20,40 @@
  *
  */
 
-import * as React from 'react';
-import { connect } from '../../reduxConnect';
 import classNames from 'classnames';
-import { bindActionCreators } from 'redux';
+import * as React from 'react';
+import { bindActionCreators, Dispatch } from 'redux';
 import { createStructuredSelector } from 'reselect';
-
-import Inner from './Inner';
+import {
+  blurAllCells,
+  focusCell,
+  resizeCell,
+  ResizeCellAction
+} from '../../actions/cell';
+import { connect } from '../../reduxConnect';
+import { RootState } from '../../selector';
+import {
+  isEditMode,
+  isInsertMode,
+  isLayoutMode,
+  isPreviewMode,
+  isResizeMode
+} from '../../selector/display';
 import {
   editableConfig,
   node,
-  purifiedNode,
-  NodeProps
+  NodeProps,
+  purifiedNode
 } from '../../selector/editable';
-import {
-  isPreviewMode,
-  isEditMode,
-  isResizeMode,
-  isInsertMode,
-  isLayoutMode
-} from '../../selector/display';
-import {
-  resizeCell,
-  focusCell,
-  blurAllCells,
-  ResizeCellAction
-} from '../../actions/cell';
-import Resizable from './Resizable';
-
 import { ComponetizedCell } from '../../types/editable';
-import { Dispatch } from 'redux';
 import {
+  BlurAllCellsAction,
   FocusCellAction,
   removeCell,
   RemoveCellAction
 } from './../../actions/cell/core';
-import { BlurAllCellsAction } from './../../actions/cell/core';
-import { RootState } from '../../selector';
+import Inner from './Inner';
+import Resizable from './Resizable';
 
 const gridClass = ({ node: { size }, ...rest }: ComponetizedCell): string => {
   if (rest.isPreviewMode || rest.isEditMode) {
@@ -81,8 +78,11 @@ class Cell extends React.PureComponent<CellProps> {
       rowWidth,
       rowHeight,
       updateDimensions,
-      node: { inline, resizable, hasInlineNeighbour, focused },
+      node: { inline, resizable, hasInlineNeighbour, focused, isDraft },
     } = this.props;
+    if (isDraft && this.props.isPreviewMode) {
+      return null;
+    }
 
     return (
       <div
@@ -90,6 +90,7 @@ class Cell extends React.PureComponent<CellProps> {
           'ory-cell-has-inline-neighbour': hasInlineNeighbour,
           [`ory-cell-inline-${inline || ''}`]: inline,
           'ory-cell-focused': focused,
+          'ory-cell-is-draft': isDraft,
           'ory-cell-resizing-overlay': this.props.isResizeMode,
           'ory-cell-bring-to-front':
             !this.props.isResizeMode && !this.props.isLayoutMode && inline, // inline must not be active for resize/layout

--- a/packages/core/src/reducer/editable/__tests__/index.test.ts
+++ b/packages/core/src/reducer/editable/__tests__/index.test.ts
@@ -20,12 +20,12 @@
  *
  */
 
-import { combineReducers, createStore, applyMiddleware } from 'redux';
-import { rawEditableReducer } from '../index';
-import * as actions from '../../../actions/cell/index';
-import { decorate } from '../helper/tree';
-import { cellOrder } from '../helper/order';
+import { applyMiddleware, combineReducers, createStore } from 'redux';
 import thunk from 'redux-thunk';
+import * as actions from '../../../actions/cell/index';
+import { cellOrder } from '../helper/order';
+import { decorate } from '../helper/tree';
+import { rawEditableReducer } from '../index';
 
 const walker = ({ cells = [], rows = [], hover = null, ...other }) => {
   if (cells.length) {

--- a/packages/core/src/reducer/editable/tree.ts
+++ b/packages/core/src/reducer/editable/tree.ts
@@ -21,39 +21,37 @@
  */
 
 import pathOr from 'ramda/src/pathOr';
-
+import { AnyAction } from 'redux';
 import {
-  optimizeCell,
-  optimizeRow,
-  optimizeRows,
-  optimizeCells,
-  flatten
-} from './helper/optimize';
-import { mergeDecorator } from './helper/merge';
-import { isHoveringThis } from './helper/hover';
-import { resizeCells } from './helper/sizing';
-import { computeRow } from './helper/inline';
-import { createCell, createRow } from '../../types/editable';
-import {
-  CELL_REMOVE,
-  CELL_UPDATE_LAYOUT,
-  CELL_UPDATE_CONTENT,
-  CELL_INSERT_LEFT_OF,
-  CELL_INSERT_RIGHT_OF,
+  CELL_BLUR,
+  CELL_BLUR_ALL,
+  CELL_DRAG_HOVER,
+  CELL_FOCUS,
   CELL_INSERT_ABOVE,
   CELL_INSERT_BELOW,
   CELL_INSERT_INLINE_LEFT,
   CELL_INSERT_INLINE_RIGHT,
-  CELL_DRAG_HOVER,
+  CELL_INSERT_LEFT_OF,
+  CELL_INSERT_RIGHT_OF,
+  CELL_REMOVE,
   CELL_RESIZE,
-  CELL_FOCUS,
-  CELL_BLUR,
-  CELL_BLUR_ALL
+  CELL_UPDATE_CONTENT,
+  CELL_UPDATE_IS_DRAFT,
+  CELL_UPDATE_LAYOUT
 } from '../../actions/cell';
-
-import { Cell, Row } from '../../types/editable';
-import { AnyAction } from 'redux';
+import { Cell, createCell, createRow, Row } from '../../types/editable';
 import { CellHoverAction } from './../../actions/cell/drag';
+import { isHoveringThis } from './helper/hover';
+import { computeRow } from './helper/inline';
+import { mergeDecorator } from './helper/merge';
+import {
+  flatten,
+  optimizeCell,
+  optimizeCells,
+  optimizeRow,
+  optimizeRows
+} from './helper/optimize';
+import { resizeCells } from './helper/sizing';
 
 const inner = (cb: Function, action: Object) => (state: Object) =>
   cb(state, action);
@@ -84,6 +82,12 @@ export const cell = (s: Cell, a: AnyAction): Cell =>
       };
 
       switch (action.type) {
+        case CELL_UPDATE_IS_DRAFT:
+          if (action.id === state.id) {
+            // If this cell is being focused, set the data
+            return { ...reduce(), isDraft: action.isDraft };
+          }
+          return { ...reduce(), focused: false, focusSource: null };
         case CELL_UPDATE_CONTENT:
           if (action.id === state.id) {
             // If this cell is being updated, set the data

--- a/packages/core/src/selector/index.ts
+++ b/packages/core/src/selector/index.ts
@@ -19,15 +19,17 @@
  * @author Aeneas Rekkas <aeneas+oss@aeneas.io>
  *
  */
-import { editable, editables } from './editable';
 import { Store } from 'redux';
 import { RootState } from '../types/state';
 import * as DisplaySelectors from './display';
+import * as EditableSelectors from './editable';
+import { editable, editables } from './editable';
 import * as SettingSelectors from './setting';
 
 export const Selectors = {
   Display: DisplaySelectors,
   Setting: SettingSelectors,
+  Editable: EditableSelectors,
 };
 export const selectors = (store: Store<RootState>) => ({
   editable: (id: string) => editable(store.getState(), { id }),

--- a/packages/core/src/service/plugin/index.ts
+++ b/packages/core/src/service/plugin/index.ts
@@ -273,9 +273,10 @@ export default class PluginService {
       layout = {},
       inline,
       size,
+      isDraft,
       id,
     } = state;
-    const newState: EditorState = { id, inline, size };
+    const newState: EditorState = { id, inline, size, isDraft };
 
     const {
       plugin: { name: contentName = null, version: contentVersion = '*' } = {},

--- a/packages/core/src/service/plugin/index.ts
+++ b/packages/core/src/service/plugin/index.ts
@@ -319,10 +319,19 @@ export default class PluginService {
 
   // tslint:disable-next-line:no-any
   serialize = (state: any): EditableType => {
-    const { rows = [], cells = [], content, layout, inline, size, id } = state;
+    const {
+      rows = [],
+      cells = [],
+      content,
+      layout,
+      inline,
+      isDraft,
+      size,
+      id,
+    } = state;
 
     // tslint:disable-next-line:no-any
-    const newState: any = { id, inline, size };
+    const newState: any = { id, inline, size, isDraft };
     if (content && content.plugin) {
       newState.content = {
         plugin: { name: content.plugin.name, version: content.plugin.version },

--- a/packages/core/src/service/plugin/missing.tsx
+++ b/packages/core/src/service/plugin/missing.tsx
@@ -21,11 +21,11 @@
  */
 
 import * as React from 'react';
-import { LayoutPluginProps } from 'src';
 import {
   ContentPluginConfig,
   ContentPluginProps,
-  LayoutPluginConfig
+  LayoutPluginConfig,
+  LayoutPluginProps
 } from './classes';
 
 const ContentMissingComponent = (props: ContentPluginProps<{}>) => (

--- a/packages/core/src/service/plugin/missing.tsx
+++ b/packages/core/src/service/plugin/missing.tsx
@@ -21,10 +21,11 @@
  */
 
 import * as React from 'react';
+import { LayoutPluginProps } from 'src';
 import {
-  LayoutPluginConfig,
   ContentPluginConfig,
-  ContentPluginProps
+  ContentPluginProps,
+  LayoutPluginConfig
 } from './classes';
 
 const ContentMissingComponent = (props: ContentPluginProps<{}>) => (
@@ -38,6 +39,7 @@ const ContentMissingComponent = (props: ContentPluginProps<{}>) => (
     }}
   >
     The requested content plugin could not be found.
+    <button onClick={props.remove}>Delete Plugin</button>
     <pre>{JSON.stringify(props, null, 2)}</pre>
   </div>
 );
@@ -52,7 +54,11 @@ export const contentMissing = ({
   version,
 });
 
-const LayoutMissingComponent: React.SFC = ({ children, ...props }) => (
+const LayoutMissingComponent: React.SFC = ({
+  children,
+  ...props
+}: // tslint:disable-next-line:no-any
+LayoutPluginProps<{}> & { children: any }) => (
   <div>
     <div
       style={{
@@ -64,6 +70,7 @@ const LayoutMissingComponent: React.SFC = ({ children, ...props }) => (
       }}
     >
       The requested layout plugin could not be found.
+      <button onClick={props.remove}>Delete Plugin</button>
       <pre>{JSON.stringify(props, null, 2)}</pre>
     </div>
     {children}

--- a/packages/core/src/types/editable.ts
+++ b/packages/core/src/types/editable.ts
@@ -59,6 +59,7 @@ export type AbstractCell<T> = {
   hover?: string;
   inline?: string | null;
   focused?: boolean;
+  isDraft?: boolean;
   focusSource?: string;
   resizable?: boolean;
   bounds?: { left: number; right: number };

--- a/packages/plugins/content/html5-video/src/Controls/Html5VideoDefaultControls.tsx
+++ b/packages/plugins/content/html5-video/src/Controls/Html5VideoDefaultControls.tsx
@@ -1,9 +1,8 @@
-import * as React from 'react';
-import { Html5VideoControlsProps } from './../types/controls';
 import TextField from '@material-ui/core/TextField';
 import { BottomToolbar } from '@react-page/ui';
-
+import * as React from 'react';
 import { defaultHtml5VideoState } from '../default/state';
+import { Html5VideoControlsProps } from './../types/controls';
 
 export interface Html5VideoDefaultControlsProps {}
 
@@ -17,6 +16,7 @@ const Html5VideoDefaultControls: React.SFC<Html5VideoControlsProps> = props => {
     commitUrl,
     changeUrlPreview,
     focused,
+
     remove,
   } = props;
   return (
@@ -24,6 +24,7 @@ const Html5VideoDefaultControls: React.SFC<Html5VideoControlsProps> = props => {
       open={focused}
       title={props.translations.pluginName}
       onDelete={remove}
+      {...props}
     >
       <TextField
         placeholder={props.translations.urlPlaceholder}

--- a/packages/plugins/content/image/src/Controls/ImageDefaultControls.tsx
+++ b/packages/plugins/content/image/src/Controls/ImageDefaultControls.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
-import { ImageControlsProps } from '../types/controls';
+import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
-import Checkbox from '@material-ui/core/Checkbox';
 import { BottomToolbar, ImageUpload } from '@react-page/ui';
+import * as React from 'react';
+import { ImageControlsProps } from '../types/controls';
 
 const ImageDefaultControls: React.SFC<ImageControlsProps> = props => {
   const {
@@ -26,6 +26,7 @@ const ImageDefaultControls: React.SFC<ImageControlsProps> = props => {
           open={props.focused}
           title={props.translations.pluginName}
           onDelete={remove}
+          {...props}
         >
           <div style={{ display: 'flex' }}>
             {props.imageUpload && (

--- a/packages/plugins/content/slate/src/Controls/index.tsx
+++ b/packages/plugins/content/slate/src/Controls/index.tsx
@@ -193,7 +193,7 @@ class Slate extends React.PureComponent<SlateProps, SlateState> {
   }
 
   render() {
-    const { focused, readOnly, plugins } = this.props;
+    const { focused, readOnly, plugins, remove } = this.props;
 
     const editorState = this.getState();
     const showHoverToolbar =
@@ -238,7 +238,12 @@ class Slate extends React.PureComponent<SlateProps, SlateState> {
         />
 
         {!readOnly ? (
-          <BottomToolbar open={showBottomToolbar} dark={true} hideHeader={true}>
+          <BottomToolbar
+            open={showBottomToolbar}
+            dark={true}
+            onDelete={remove}
+            {...this.props}
+          >
             <ToolbarButtons
               {...this.props}
               translations={this.props.translations}

--- a/packages/plugins/content/slate/src/serialization/index.tsx
+++ b/packages/plugins/content/slate/src/serialization/index.tsx
@@ -1,13 +1,11 @@
-import Html from 'slate-html-serializer';
-
-import { SlateState } from '../types/state';
-import { Value, ValueJSON } from 'slate';
-
-import { EditorState } from '@react-page/core/lib/types/editor';
 import { PluginProps } from '@react-page/core/lib/service/plugin/classes';
-
+import { EditorState } from '@react-page/core/lib/types/editor';
+import { Value, ValueJSON } from 'slate';
+import Html from 'slate-html-serializer';
 import parseHtml from '../parseHtml/parseHtml';
+import DEFAULT_NODE from '../plugins/DEFAULT_NODE';
 import SlatePlugin from '../types/SlatePlugin';
+import { SlateState } from '../types/state';
 
 type AdditionalSlateFunctions = {
   slateToHtml: (editorState: EditorState) => string;
@@ -38,6 +36,7 @@ export default ({
     rules: rules,
     // tslint:disable-next-line:no-any
     parseHtml,
+    defaultBlock: DEFAULT_NODE,
   });
 
   const htmlToSlate = (htmlString: string) => html.deserialize(htmlString);

--- a/packages/plugins/content/slate/src/types/initialSlateState.ts
+++ b/packages/plugins/content/slate/src/types/initialSlateState.ts
@@ -3,6 +3,7 @@ import { SlatePluginOrFactory } from './SlatePlugin';
 export type SlatePluginNode = {
   plugin: SlatePluginOrFactory;
   children?: SlateDefNode[];
+  data?: object;
 };
 
 export type SlateDefNode = SlatePluginNode | string;

--- a/packages/plugins/content/slate/src/utils/transformInitialSlateState.ts
+++ b/packages/plugins/content/slate/src/utils/transformInitialSlateState.ts
@@ -1,12 +1,11 @@
 import { Value } from 'slate';
-import SlatePlugin from '../types/SlatePlugin';
-
-import flattenDeep from './flattenDeep';
 import {
   InitialSlateStateDef,
   SlateDefNode,
   SlatePluginNode
 } from '../types/initialSlateState';
+import SlatePlugin from '../types/SlatePlugin';
+import flattenDeep from './flattenDeep';
 
 /**
  * FIXME: transformInitialSlateState does some polymorphic type magic, so that it is directly
@@ -48,6 +47,7 @@ const transformChildren = (defNodes: SlateDefNode[]) =>
         return {
           object: firstComponentPlugin.pluginDefintion.object,
           type: firstComponentPlugin.pluginDefintion.type,
+          data: defPluginNode.data,
           nodes: defPluginNode.children
             ? transformChildren(defPluginNode.children)
             : [],

--- a/packages/plugins/content/spacer/src/Controls/SpacerDefaultControls.tsx
+++ b/packages/plugins/content/spacer/src/Controls/SpacerDefaultControls.tsx
@@ -1,11 +1,10 @@
-import * as React from 'react';
-import { SpacerControlsProps } from '../types/controls';
-import { Resizable } from 'react-resizable';
-import { BottomToolbar } from '@react-page/ui';
-
-import { defaultSpacerState } from './../default/state';
-import classNames from 'classnames';
 import TextField from '@material-ui/core/TextField';
+import { BottomToolbar } from '@react-page/ui';
+import classNames from 'classnames';
+import * as React from 'react';
+import { Resizable } from 'react-resizable';
+import { SpacerControlsProps } from '../types/controls';
+import { defaultSpacerState } from './../default/state';
 
 const faintBlack = 'rgba(0, 0, 0, 0.12)';
 
@@ -37,6 +36,7 @@ const SpacerDefaultControls: React.SFC<SpacerControlsProps> = props => {
         >
           <div style={{ height, position: 'relative' }}>
             <BottomToolbar
+              {...props}
               icon={props.IconComponent}
               open={props.focused}
               title={props.translations.pluginName}

--- a/packages/plugins/content/video/src/Controls/VideoDefaultControls.tsx
+++ b/packages/plugins/content/video/src/Controls/VideoDefaultControls.tsx
@@ -20,12 +20,11 @@
  *
  */
 
-import * as React from 'react';
 import TextField from '@material-ui/core/TextField';
-
 import { BottomToolbar } from '@react-page/ui';
-import { VideoControlsProps } from '../types/controls';
+import * as React from 'react';
 import { defaultVideoState } from '../default/state';
+import { VideoControlsProps } from '../types/controls';
 
 const Form: React.SFC<VideoControlsProps> = props => {
   const {
@@ -42,6 +41,7 @@ const Form: React.SFC<VideoControlsProps> = props => {
       title={props.translations.pluginName}
       icon={props.IconComponent}
       onDelete={remove}
+      {...props}
     >
       <TextField
         placeholder={props.translations.placeholder}

--- a/packages/plugins/createPluginMaterialUi/src/Controls/index.tsx
+++ b/packages/plugins/createPluginMaterialUi/src/Controls/index.tsx
@@ -1,12 +1,11 @@
-import React, { Fragment, useState, useCallback } from 'react';
-import { ControlProps, ControlsLayout } from '../types';
-
-import {
-  AutoForm as AutoFormOrg,
-  AutoFields as AutoFieldsOrg
-} from 'uniforms-material';
-import debounce from 'lodash.debounce';
 import { BottomToolbar } from '@react-page/ui';
+import debounce from 'lodash.debounce';
+import React, { Fragment, useCallback, useState } from 'react';
+import {
+  AutoFields as AutoFieldsOrg,
+  AutoForm as AutoFormOrg
+} from 'uniforms-material';
+import { ControlProps, ControlsLayout } from '../types';
 import makeUniformsSchema from '../utils/makeUniformsSchema';
 
 // see https://github.com/vazco/uniforms/issues/617
@@ -48,6 +47,7 @@ function Controls<T>(props: ControlProps<T>) {
         title={props.text}
         onDelete={remove}
         icon={props.IconComponent}
+        {...props}
       >
         <div style={{ marginBottom: 24, maxHeight: '50vh', overflow: 'auto' }}>
           <AutoForm

--- a/packages/plugins/layout/background/src/Controls/BackgroundDefaultControls.tsx
+++ b/packages/plugins/layout/background/src/Controls/BackgroundDefaultControls.tsx
@@ -1,20 +1,19 @@
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Slider from '@material-ui/core/Slider';
+import Switch from '@material-ui/core/Switch';
+import Tab from '@material-ui/core/Tab';
+import Tabs from '@material-ui/core/Tabs';
+import Typography from '@material-ui/core/Typography';
+import ColorIcon from '@material-ui/icons/ColorLens';
+import GradientIcon from '@material-ui/icons/Gradient';
+import ImageIcon from '@material-ui/icons/Landscape';
+import { BottomToolbar } from '@react-page/ui';
 import * as React from 'react';
 import { BackgroundControlsProps } from '../types/controls';
 import { ModeEnum } from '../types/ModeEnum';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Switch from '@material-ui/core/Switch';
 import ColorComponent from './sub/Color';
-import LinearGradientComponent from './sub/LinearGradient';
 import ImageComponent from './sub/Image';
-import { BottomToolbar } from '@react-page/ui';
-
-import Tabs from '@material-ui/core/Tabs';
-import Tab from '@material-ui/core/Tab';
-import ImageIcon from '@material-ui/icons/Landscape';
-import ColorIcon from '@material-ui/icons/ColorLens';
-import GradientIcon from '@material-ui/icons/Gradient';
-import Typography from '@material-ui/core/Typography';
-import Slider from '@material-ui/core/Slider';
+import LinearGradientComponent from './sub/LinearGradient';
 
 export interface BackgroundDefaultControlsState {
   mode: ModeEnum;
@@ -56,6 +55,7 @@ class BackgroundDefaultControls extends React.Component<
         title={this.props.translations.pluginName}
         icon={this.props.IconComponent}
         onDelete={remove}
+        {...this.props}
       >
         <Tabs
           value={this.state.mode}

--- a/packages/renderer/src/index.tsx
+++ b/packages/renderer/src/index.tsx
@@ -20,18 +20,18 @@
  *
  */
 
-import * as React from 'react';
-import classNames from 'classnames';
-import PluginService from '@react-page/core/lib/service/plugin';
 import { editable as reducer } from '@react-page/core/lib/reducer/editable';
+import PluginService from '@react-page/core/lib/service/plugin';
+import { Plugins } from '@react-page/core/lib/service/plugin/classes';
 import {
   Cell,
-  Row,
+  Content,
+  EditableType,
   Layout,
-  Content
+  Row
 } from '@react-page/core/lib/types/editable';
-import { Plugins } from '@react-page/core/lib/service/plugin/classes';
-import { EditableType } from '@react-page/core/lib/types/editable';
+import classNames from 'classnames';
+import * as React from 'react';
 
 const gridClass = (size: number = 12): string =>
   `ory-cell-sm-${size} ory-cell-xs-12`;
@@ -66,12 +66,16 @@ const HTMLCell: React.SFC<Cell> = props => {
     inline,
     size,
     id,
+    isDraft,
   } = props;
   const cn = classNames('ory-cell', gridClass(size), {
     'ory-cell-has-inline-neighbour': hasInlineNeighbour,
     [`ory-cell-inline-${inline || ''}`]: inline,
   });
 
+  if (isDraft) {
+    return null;
+  }
   if (layout.plugin) {
     const {
       state,

--- a/packages/ui/src/BottomToolbar/index.tsx
+++ b/packages/ui/src/BottomToolbar/index.tsx
@@ -9,6 +9,7 @@ import Drawer from '@material-ui/core/Drawer';
 import Delete from '@material-ui/icons/Delete';
 import FormatSize from '@material-ui/icons/FormatSize';
 import * as React from 'react';
+import DraftSwitch from '../DraftSwitch';
 import ThemeProvider, { darkTheme } from '../ThemeProvider';
 
 const darkBlack = 'rgba(0, 0, 0, 0.87)';
@@ -16,7 +17,7 @@ const bright = 'rgba(255,255,255, 0.98)';
 const brightBorder = 'rgba(0, 0, 0, 0.12)';
 export interface BottomToolbarProps {
   open?: boolean;
-  hideHeader?: boolean;
+
   children?: Object;
   className?: string;
   dark: boolean;
@@ -25,6 +26,9 @@ export interface BottomToolbarProps {
   onDelete?: () => void;
   // tslint:disable-next-line:no-any
   icon?: any;
+  // FIXME: seems like we use more and more information about the current cell. we should refactor this
+  id: string;
+  editable: string;
 }
 
 const SIZES = [1, 0.8, 0.6, 1.2];
@@ -34,11 +38,13 @@ const BottomToolbar: React.SFC<BottomToolbarProps> = ({
   children,
   className,
   dark = false,
-  hideHeader = false,
+
   anchor = 'bottom',
   onDelete = null,
   title,
   icon = null,
+  id,
+  editable,
 }) => {
   const [size, setSize] = React.useState(lastSize);
   const toggleSize = () => {
@@ -85,9 +91,19 @@ const BottomToolbar: React.SFC<BottomToolbarProps> = ({
             transition: '0.3s',
           }}
         >
-          {!hideHeader ? (
-            <>
-              <Grid container={true} direction="row" alignItems="center">
+          {children}
+          <Divider
+            style={{
+              marginLeft: -24,
+              marginRight: -24,
+              marginTop: 12,
+              marginBottom: 12,
+            }}
+          />
+
+          <>
+            <Grid container={true} direction="row" alignItems="center">
+              {icon || title ? (
                 <Grid item={true}>
                   <Avatar
                     children={icon || (title ? title[0] : '')}
@@ -96,42 +112,32 @@ const BottomToolbar: React.SFC<BottomToolbarProps> = ({
                     }}
                   />
                 </Grid>
-                <Grid item={true}>
-                  <Typography variant="subtitle1">{title}</Typography>
-                </Grid>
-
-                <Grid item={true} style={{ marginLeft: 'auto' }}>
-                  {onDelete ? (
-                    <IconButton
-                      onClick={onDelete}
-                      aria-label="delete"
-                      color="secondary"
-                    >
-                      <Delete fontSize="small" />
-                    </IconButton>
-                  ) : null}
-                  <IconButton
-                    onClick={toggleSize}
-                    aria-label="toggle Size"
-                    color="secondary"
-                  >
-                    <FormatSize fontSize="small" />
-                  </IconButton>
-                </Grid>
+              ) : null}
+              <Grid item={true}>
+                <Typography variant="subtitle1">{title}</Typography>
               </Grid>
 
-              <Divider
-                style={{
-                  marginLeft: -24,
-                  marginRight: -24,
-                  marginTop: 12,
-                  marginBottom: 12,
-                }}
-              />
-            </>
-          ) : null}
-
-          {children}
+              <Grid item={true} style={{ marginLeft: 'auto' }}>
+                <DraftSwitch id={id} editable={editable} />
+                {onDelete ? (
+                  <IconButton
+                    onClick={onDelete}
+                    aria-label="delete"
+                    color="secondary"
+                  >
+                    <Delete fontSize="small" />
+                  </IconButton>
+                ) : null}
+                <IconButton
+                  onClick={toggleSize}
+                  aria-label="toggle Size"
+                  color="secondary"
+                >
+                  <FormatSize fontSize="small" />
+                </IconButton>
+              </Grid>
+            </Grid>
+          </>
         </div>
       </Drawer>
     </ThemeProvider>

--- a/packages/ui/src/BottomToolbar/index.tsx
+++ b/packages/ui/src/BottomToolbar/index.tsx
@@ -30,6 +30,8 @@ export interface BottomToolbarProps {
   // FIXME: seems like we use more and more information about the current cell. we should refactor this
   id: string;
   editable: string;
+  // tslint:disable-next-line:no-any
+  theme: any;
 }
 
 const SIZES = [1, 0.8, 0.6, 1.2];
@@ -39,6 +41,7 @@ const BottomToolbar: React.SFC<BottomToolbarProps> = ({
   children,
   className,
   dark = false,
+  theme,
 
   anchor = 'bottom',
   onDelete = null,
@@ -56,7 +59,7 @@ const BottomToolbar: React.SFC<BottomToolbarProps> = ({
   };
 
   return (
-    <ThemeProvider theme={dark ? darkTheme : null}>
+    <ThemeProvider theme={theme ? theme : dark ? darkTheme : null}>
       <Drawer
         SlideProps={{
           unmountOnExit: true,

--- a/packages/ui/src/BottomToolbar/index.tsx
+++ b/packages/ui/src/BottomToolbar/index.tsx
@@ -10,6 +10,7 @@ import Delete from '@material-ui/icons/Delete';
 import FormatSize from '@material-ui/icons/FormatSize';
 import * as React from 'react';
 import DraftSwitch from '../DraftSwitch';
+import DuplicateButton from '../DuplicateButton';
 import ThemeProvider, { darkTheme } from '../ThemeProvider';
 
 const darkBlack = 'rgba(0, 0, 0, 0.87)';
@@ -116,25 +117,30 @@ const BottomToolbar: React.SFC<BottomToolbarProps> = ({
               <Grid item={true}>
                 <Typography variant="subtitle1">{title}</Typography>
               </Grid>
+              <Grid item={true}>
+                {' '}
+                <IconButton
+                  onClick={toggleSize}
+                  aria-label="toggle Size"
+                  color="primary"
+                >
+                  <FormatSize />
+                </IconButton>
+              </Grid>
 
               <Grid item={true} style={{ marginLeft: 'auto' }}>
                 <DraftSwitch id={id} editable={editable} />
+                <DuplicateButton id={id} editable={editable} />
+
                 {onDelete ? (
                   <IconButton
                     onClick={onDelete}
                     aria-label="delete"
                     color="secondary"
                   >
-                    <Delete fontSize="small" />
+                    <Delete />
                   </IconButton>
                 ) : null}
-                <IconButton
-                  onClick={toggleSize}
-                  aria-label="toggle Size"
-                  color="secondary"
-                >
-                  <FormatSize fontSize="small" />
-                </IconButton>
               </Grid>
             </Grid>
           </>

--- a/packages/ui/src/DraftSwitch/index.tsx
+++ b/packages/ui/src/DraftSwitch/index.tsx
@@ -12,19 +12,26 @@ const DraftSwitch = ({ id, node, setDraft }) => {
       labelPlacement="start"
       control={
         <Switch
+          color="primary"
           checked={!node.isDraft}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             setDraft(id, !e.target.checked)
           }
         />
       }
-      label={node.isDraft ? <NonVisibleIcon /> : <VisibleIcon />}
+      label={
+        node.isDraft ? (
+          <NonVisibleIcon style={{ marginTop: 5 }} />
+        ) : (
+          <VisibleIcon style={{ marginTop: 5 }} />
+        )
+      }
     />
   ) : null;
 };
 
 const mapStateToProps = createStructuredSelector({
-  node: Selectors.Editable.purifiedNode,
+  node: Selectors.Editable.node,
 });
 
 const mapDispatchToProps = {

--- a/packages/ui/src/DraftSwitch/index.tsx
+++ b/packages/ui/src/DraftSwitch/index.tsx
@@ -1,0 +1,37 @@
+import { FormControlLabel, Switch } from '@material-ui/core';
+import VisibleIcon from '@material-ui/icons/Visibility';
+import NonVisibleIcon from '@material-ui/icons/VisibilityOff';
+import { Actions, connect, Selectors } from '@react-page/core';
+import React from 'react';
+import { createStructuredSelector } from 'reselect';
+
+const DraftSwitch = ({ id, node, setDraft }) => {
+  return node ? (
+    <FormControlLabel
+      style={{ marginRight: 5 }}
+      labelPlacement="start"
+      control={
+        <Switch
+          checked={!node.isDraft}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setDraft(id, !e.target.checked)
+          }
+        />
+      }
+      label={node.isDraft ? <NonVisibleIcon /> : <VisibleIcon />}
+    />
+  ) : null;
+};
+
+const mapStateToProps = createStructuredSelector({
+  node: Selectors.Editable.purifiedNode,
+});
+
+const mapDispatchToProps = {
+  setDraft: Actions.Cell.updateCellIsDraft,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(DraftSwitch);

--- a/packages/ui/src/DuplicateButton/index.tsx
+++ b/packages/ui/src/DuplicateButton/index.tsx
@@ -1,0 +1,30 @@
+import { IconButton } from '@material-ui/core';
+import Icon from '@material-ui/icons/FileCopy';
+import { Actions, connect, Selectors } from '@react-page/core';
+import React from 'react';
+import { createStructuredSelector } from 'reselect';
+
+const DuplicateButton = ({ id, node, duplicateCell }) => {
+  return node ? (
+    <IconButton
+      onClick={() => duplicateCell(node, node)}
+      aria-label="delete"
+      color="default"
+    >
+      <Icon />
+    </IconButton>
+  ) : null;
+};
+
+const mapStateToProps = createStructuredSelector({
+  node: Selectors.Editable.node,
+});
+
+const mapDispatchToProps = {
+  duplicateCell: Actions.Cell.duplicateCell,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(DuplicateButton);


### PR DESCRIPTION
_this PR is based on my previous PR: https://github.com/react-page/react-page/pull/744_

The bottom toolbar when selecting a cell now has new features:

- you can hide and show cells, setting them into a "draft" mode. These cells are only visible while in edit mode, but slightly transparent. They are not visible when rendered with readOnly/htmlRenderer
- a new clone button duplicates a cell. This works with layout plugins too! The new element will always inserted the cloned element.
- The title-bar with these actions has been moved below the rest of the toolbar. This is because i added these actions to the slate plugin as well and it looked better when the normal slate toolbar is next to the content.

<img width="518" alt="Bildschirmfoto 2019-11-18 um 22 31 11" src="https://user-images.githubusercontent.com/1972353/69095680-22c32880-0a53-11ea-94cc-4e4a4a802fa3.png">

The clone action was easy to do in the end, but it was not obvious how to do it. The action creator of the insertActions have some properties that are not obvious to use. It could also have been done in the reducer, but it was more easy to wrap an already existing action (insertCellBelow).