### PR TITLE
correct link to slack in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ Original Library created by [@aeneasr](https://github.com/aeneasr) [@ory](https:
 
 ## Community
 
-join us on slack: https://react-page.slack.com
+join us on slack: https://reactpage.slack.com


### PR DESCRIPTION
## Proposed changes

Following [discussion](https://github.com/react-page/react-page/issues/696#issuecomment-557559899) on #696 it seems that the URL in `README.md` should match the correct URL for the slack channel.

## Types of changes

- [x] minor correction of a link in `README.md`
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

Only the readme was adjusted and so no tests were executed, and no functionality should have changed due to the changes.

## Closing issues

No open issues are addressed by this.
