### PR TITLE
feat: allow to pass react-dnd-backend

### DIFF
--- a/packages/core/src/components/DragDropProvider/index.tsx
+++ b/packages/core/src/components/DragDropProvider/index.tsx
@@ -2,4 +2,6 @@ import React from 'react';
 import { DndProvider } from 'react-dnd-cjs';
 import HTML5Backend from 'react-dnd-html5-backend-cjs';
 
-export default props => <DndProvider backend={HTML5Backend} {...props} />;
+export default ({ dndBackend = HTML5Backend, ...props }) => (
+  <DndProvider backend={dndBackend} {...props} />
+);

--- a/packages/core/src/components/Editable/index.tsx
+++ b/packages/core/src/components/Editable/index.tsx
@@ -1,6 +1,6 @@
 import { equals } from 'ramda';
 import * as React from 'react';
-import Editor from '../../';
+import Editor, { DndBackend } from '../../';
 import { ReduxProvider } from '../../reduxConnect';
 import { editable } from '../../selector/editable';
 import { EditorState } from '../../types/editor';
@@ -13,6 +13,7 @@ export type PropTypes = {
   id: string;
   editor: Editor;
   onChange?: Function;
+  dndBackend?: DndBackend;
 };
 class Editable extends React.PureComponent<PropTypes> {
   unsubscribe: Function;
@@ -70,11 +71,12 @@ class Editable extends React.PureComponent<PropTypes> {
     const {
       id,
       editor: { store, defaultPlugin },
+      dndBackend,
     } = this.props;
 
     return (
       <ReduxProvider store={store}>
-        <DragDropProvider>
+        <DragDropProvider dndBackend={dndBackend}>
           <HotKeyDecorator id={id}>
             <BlurGate>
               <Inner id={id} defaultPlugin={defaultPlugin} />

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@
  *
  */
 
+import { BackendFactory } from 'dnd-core-cjs';
 import forEach from 'ramda/src/forEach';
 import { NativeTypes } from 'react-dnd-html5-backend-cjs';
 import { Middleware, Store } from 'redux';
@@ -52,6 +53,7 @@ import createStore from './store';
 import { EditableType, NativeFactory } from './types/editable';
 import { RootState } from './types/state';
 
+export { BackendFactory as DndBackend };
 export { shouldPureComponentUpdate };
 export {
   Plugin,

--- a/packages/editor/src/editor/EditableEditor.tsx
+++ b/packages/editor/src/editor/EditableEditor.tsx
@@ -3,7 +3,7 @@ import EditorUI from '@react-page/ui';
 import React, { useEffect, useRef } from 'react';
 import StickyWrapper from './StickyWrapper';
 
-export default ({ plugins, defaultPlugin, value, onChange }) => {
+export default ({ plugins, defaultPlugin, value, onChange, dndBackend }) => {
   const editorRef = useRef({
     editor: new Editor({ defaultPlugin, plugins }),
     editorState: null,
@@ -26,8 +26,17 @@ export default ({ plugins, defaultPlugin, value, onChange }) => {
     <StickyWrapper>
       {stickyNess => (
         <>
-          <Editable id={editorState.id} editor={editor} onChange={onChange} />
-          <EditorUI editor={editor} stickyNess={stickyNess} />
+          <Editable
+            id={editorState.id}
+            editor={editor}
+            onChange={onChange}
+            dndBackend={dndBackend}
+          />
+          <EditorUI
+            editor={editor}
+            stickyNess={stickyNess}
+            dndBackend={dndBackend}
+          />
         </>
       )}
     </StickyWrapper>

--- a/packages/editor/src/editor/index.tsx
+++ b/packages/editor/src/editor/index.tsx
@@ -1,5 +1,6 @@
 import {
   ContentPluginConfig,
+  DndBackend,
   EditableType,
   LayoutPluginConfig,
   lazyLoad,
@@ -13,6 +14,7 @@ const EditableEditor = lazyLoad(() => import('./EditableEditor'));
 type Props = {
   plugins?: Plugins;
   defaultPlugin?: ContentPluginConfig | LayoutPluginConfig;
+  dndBackendd?: DndBackend;
   value?: EditableType;
   onChange?: (v: EditableType) => void;
   readOnly?: boolean;
@@ -23,6 +25,7 @@ const Editor: React.FC<Props> = ({
   readOnly,
   value,
   onChange,
+  dndBackendd,
 }) =>
   readOnly ? (
     <HTMLRenderer state={value} plugins={plugins} />
@@ -32,6 +35,7 @@ const Editor: React.FC<Props> = ({
       defaultPlugin={defaultPlugin}
       value={value}
       onChange={onChange}
+      dndBackend={dndBackendd}
     />
   );
 

--- a/packages/ui/src/EditorUI/index.tsx
+++ b/packages/ui/src/EditorUI/index.tsx
@@ -1,4 +1,4 @@
-import { Editor } from '@react-page/core';
+import { DndBackend, Editor } from '@react-page/core';
 import React from 'react';
 import DisplayModeToggle, { StickyNess } from '../DisplayModeToggle/index';
 import Provider from '../Provider';
@@ -12,12 +12,14 @@ export default ({
     shouldStickToBottom: false,
     rightOffset: 0,
   },
+  dndBackend,
 }: {
   // tslint:disable-next-line:no-any
   editor: Editor;
   stickyNess?: StickyNess;
+  dndBackend?: DndBackend;
 }) => (
-  <Provider editor={editor}>
+  <Provider editor={editor} dndBackend={dndBackend}>
     <Trash />
     <DisplayModeToggle stickyNess={stickyNess} />
     <Toolbar />

--- a/packages/ui/src/Provider/index.tsx
+++ b/packages/ui/src/Provider/index.tsx
@@ -1,32 +1,12 @@
-/*
- * This file is part of ORY Editor.
- *
- * ORY Editor is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * ORY Editor is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with ORY Editor.  If not, see <http://www.gnu.org/licenses/>.
- *
- * @license LGPL-3.0
- * @copyright 2016-2018 Aeneas Rekkas
- * @author Aeneas Rekkas <aeneas+oss@aeneas.io>
- *
- */
 import { Editor, ReduxProvider } from '@react-page/core';
+import { BackendFactory } from 'dnd-core-cjs';
 import * as React from 'react';
 import { DndProvider } from 'react-dnd-cjs';
 import HTML5Backend from 'react-dnd-html5-backend-cjs';
 import ThemeProvider from '../ThemeProvider/index';
-
-export interface ProviderProps {
+interface ProviderProps {
   editor: Editor;
+  dndBackend?: BackendFactory;
 }
 
 const EditorContext = React.createContext<Editor>(null);
@@ -40,9 +20,9 @@ class Provider extends React.Component<ProviderProps> {
   }
 
   public render() {
-    const { editor, children = [] } = this.props;
+    const { editor, children = [], dndBackend = HTML5Backend } = this.props;
     return (
-      <DndProvider backend={HTML5Backend}>
+      <DndProvider backend={dndBackend}>
         <ReduxProvider store={editor.store}>
           <EditorContext.Provider value={editor}>
             <ThemeProvider>{children}</ThemeProvider>

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -1,8 +1,8 @@
 // something is wrong with lerna, typescript and this import: import { lazyLoad } from '@react-page/core';
 import loadable from '@loadable/component';
 import { colorToString } from './ColorPicker/colorToString';
-import darkTheme from './ThemeProvider/DarkTheme';
 
+import darkTheme from './ThemeProvider/DarkTheme';
 const Trash = loadable(() => import('./Trash/index'));
 const Toolbar = loadable(() => import('./Toolbar/index'));
 const DisplayModeToggle = loadable(() => import('./DisplayModeToggle/index'));
@@ -26,5 +26,5 @@ export {
   darkTheme,
   ImageUpload,
   ColorPicker,
-  colorToString
+  colorToString,
 };


### PR DESCRIPTION
You can now  customize the drag n drop backend from react-dnd. See https://react-dnd.github.io/react-dnd/docs/overview#backends for more information

example 

```
import Editor from '@react-page/editor';

import TouchBackend from 'react-dnd-touch-backend-cjs'
// ...

<Editor dndBackend={TouchBackend} />

```

or if you use the older Editable / EditorUI pair:


```
import EditorUi from '@react-page/ui';
import Editable from '@react-page/core';

import TouchBackend from 'react-dnd-touch-backend-cjs'


// ...

<Editable dndBackend={TouchBackend} /> 

// ...
<EditorUi dndBackend={TouchBackend} />

```

fixes https://github.com/react-page/react-page/issues/761



@PeterKottas can you test it a little?

