### PR TITLE
[Fix] Only render tooltip in active buttons

### DIFF
--- a/packages/plugins/content/slate/src/Controls/ConditionalWrapper.tsx
+++ b/packages/plugins/content/slate/src/Controls/ConditionalWrapper.tsx
@@ -1,0 +1,2 @@
+export const ConditionalWrapper = ({ condition, wrapper, children }) =>
+  condition ? wrapper(children) : children;

--- a/packages/plugins/content/slate/src/Controls/ToolbarButton.tsx
+++ b/packages/plugins/content/slate/src/Controls/ToolbarButton.tsx
@@ -1,9 +1,9 @@
-import { lazyLoad } from "@react-page/core";
-import * as React from "react";
-import { ConditionalWrapper } from "./ConditionalWrapper";
+import { lazyLoad } from '@react-page/core';
+import * as React from 'react';
+import { ConditionalWrapper } from './ConditionalWrapper';
 
-const IconButton = lazyLoad(() => import("@material-ui/core/IconButton"));
-const Tooltip = lazyLoad(() => import("@material-ui/core/Tooltip"));
+const IconButton = lazyLoad(() => import('@material-ui/core/IconButton'));
+const Tooltip = lazyLoad(() => import('@material-ui/core/Tooltip'));
 
 const ToolbarButton: React.SFC<{
   icon: JSX.Element | string;
@@ -11,19 +11,19 @@ const ToolbarButton: React.SFC<{
   disabled?: boolean;
   onClick: React.MouseEventHandler;
   toolTip?: string;
-}> = ({ icon, isActive, onClick, disabled = false, toolTip = "" }) => (
+}> = ({ icon, isActive, onClick, disabled = false, toolTip = '' }) => (
   <ConditionalWrapper
     condition={!disabled}
-    wrapper={(children) => <Tooltip title={toolTip}>{children}</Tooltip>}
+    wrapper={children => <Tooltip title={toolTip}>{children}</Tooltip>}
   >
     <IconButton
       onMouseDown={onClick}
       style={
         isActive
-          ? { color: "rgb(0, 188, 212)" }
+          ? { color: 'rgb(0, 188, 212)' }
           : disabled
-          ? { color: "gray" }
-          : { color: "white" }
+          ? { color: 'gray' }
+          : { color: 'white' }
       }
       disabled={disabled}
     >

--- a/packages/plugins/content/slate/src/Controls/ToolbarButton.tsx
+++ b/packages/plugins/content/slate/src/Controls/ToolbarButton.tsx
@@ -1,8 +1,9 @@
-import { lazyLoad } from '@react-page/core';
-import * as React from 'react';
+import { lazyLoad } from "@react-page/core";
+import * as React from "react";
+import { ConditionalWrapper } from "./ConditionalWrapper";
 
-const IconButton = lazyLoad(() => import('@material-ui/core/IconButton'));
-const Tooltip = lazyLoad(() => import('@material-ui/core/Tooltip'));
+const IconButton = lazyLoad(() => import("@material-ui/core/IconButton"));
+const Tooltip = lazyLoad(() => import("@material-ui/core/Tooltip"));
 
 const ToolbarButton: React.SFC<{
   icon: JSX.Element | string;
@@ -10,22 +11,25 @@ const ToolbarButton: React.SFC<{
   disabled?: boolean;
   onClick: React.MouseEventHandler;
   toolTip?: string;
-}> = ({ icon, isActive, onClick, disabled = false, toolTip = '' }) => (
-  <Tooltip title={toolTip}>
+}> = ({ icon, isActive, onClick, disabled = false, toolTip = "" }) => (
+  <ConditionalWrapper
+    condition={!disabled}
+    wrapper={(children) => <Tooltip title={toolTip}>{children}</Tooltip>}
+  >
     <IconButton
       onMouseDown={onClick}
       style={
         isActive
-          ? { color: 'rgb(0, 188, 212)' }
+          ? { color: "rgb(0, 188, 212)" }
           : disabled
-          ? { color: 'gray' }
-          : { color: 'white' }
+          ? { color: "gray" }
+          : { color: "white" }
       }
       disabled={disabled}
     >
       {icon}
     </IconButton>
-  </Tooltip>
+  </ConditionalWrapper>
 );
 
 export default React.memo(ToolbarButton);


### PR DESCRIPTION
Create a ConditionalWrapper component to only render Tooltip if button is active. 

## Proposed changes

Create a new component, to avoid material ui messge in disactive slate buttons:

```
Material-UI: you are providing a disabled `button` child to the Tooltip component.
A disabled element does not fire events.
Tooltip needs to listen to the child element's events to display the title.

Add a simple wrapper element, such as a `span`.

```
Only render tooltip if button is active. 

## Types of changes

<!-- What types of changes does your code introduce to react-page? -->
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
