### PR TITLE
fix: when editor changes from display:none to visible default ui and …

### DIFF
--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -40,6 +40,13 @@ const KeepStateEditor: React.FC<EditorProps> = ({ value, ...props }) => {
       setAllowResize(checked),
     []
   );
+
+  const [hide, sethide] = React.useState(false);
+  const onSethideChanged = React.useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>, checked: boolean) =>
+      sethide(checked),
+    []
+  );
   return (
     <>
       <FormGroup row={true}>
@@ -63,17 +70,33 @@ const KeepStateEditor: React.FC<EditorProps> = ({ value, ...props }) => {
           }
           label="Allow resize in edit mode"
         />
+        <FormControlLabel
+          control={
+            <Switch
+              checked={hide}
+              onChange={onSethideChanged}
+              color="primary"
+            />
+          }
+          label="hide"
+        />
       </FormGroup>
-      <Editor
-        {...props}
-        allowMoveInEditMode={allowMove}
-        allowResizeInEditMode={allowResize}
-        value={state}
-        onChange={setState}
-      />
-      <Button variant="outlined" onClick={() => setState(value)}>
-        Reset this editor
-      </Button>
+      <div
+        style={{
+          display: hide ? 'none' : 'block',
+        }}
+      >
+        <Editor
+          {...props}
+          allowMoveInEditMode={allowMove}
+          allowResizeInEditMode={allowResize}
+          value={state}
+          onChange={setState}
+        />
+        <Button variant="outlined" onClick={() => setState(value)}>
+          Reset this editor
+        </Button>
+      </div>
     </>
   );
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "@loadable/component": "^5.10.2",
     "classnames": "^2.2.5",
-    "element-resize-event": "^3.0.3",
     "lodash.throttle": "^4.1.1",
     "is-hotkey": "~0.1.6",
     "fast-deep-equal": "^3.1.1",

--- a/packages/core/src/selector/editable/__tests__/index.test.ts
+++ b/packages/core/src/selector/editable/__tests__/index.test.ts
@@ -24,8 +24,6 @@ import expect from 'unexpected';
 
 import { purifiedNode, searchNodeEverywhere } from '../index';
 
-
-
 const state = {
   reactPage: {
     editables: {

--- a/packages/editor/src/editor/StickyWrapper.tsx
+++ b/packages/editor/src/editor/StickyWrapper.tsx
@@ -27,12 +27,22 @@ export default ({ children }) => {
     };
     document.addEventListener('scroll', calc);
     window.addEventListener('resize', calc);
+    let observer: IntersectionObserver = null;
+
+    // tslint:disable-next-line: no-any
+    if ((global as any).IntersectionObserver) {
+      observer = new IntersectionObserver(calc);
+      if (ref.current) {
+        observer.observe(ref.current);
+      }
+    }
     // do it once
     calc();
 
     return () => {
       document.removeEventListener('scroll', calc);
       window.removeEventListener('resize', calc);
+      observer?.disconnect();
     };
   }, [ref, stickyElRef]);
 

--- a/tslint.json
+++ b/tslint.json
@@ -56,7 +56,7 @@
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": false,
     "no-unused-expression": [true, "allow-fast-null-checks"],
-    "no-use-before-declare": true,
+
     "one-line": [
       true,
       "check-catch",
@@ -66,7 +66,7 @@
     ],
     "quotemark": [true, "single", "jsx-double"],
     "radix": true,
-    "semicolon": [true, "always"],
+    "semicolon": false,
     "switch-default": true,
     "trailing-comma": [
       true,
@@ -111,6 +111,11 @@
     ]
   },
   "linterOptions": {
-    "exclude": ["**/build/**/*.*", "**/*.d.ts", ".vscode", "**/node_modules/**/*.*"]
+    "exclude": [
+      "**/build/**/*.*",
+      "**/*.d.ts",
+      ".vscode",
+      "**/node_modules/**/*.*"
+    ]
   }
 }


### PR DESCRIPTION
…resize handles are wrong

fixes https://github.com/react-page/react-page/issues/803


i fixed it by using interactionObserver. This does not work in IE11, but the editor should not be used there anyway (only in readOnly mode).

@PeterKottas I'll merge and release today, i'll guess this small change is ok