### PR TITLE
adds allowNeighbours option for layout plugins

### DIFF
--- a/packages/core/src/components/Cell/Inner/index.tsx
+++ b/packages/core/src/components/Cell/Inner/index.tsx
@@ -46,6 +46,7 @@ class Inner extends React.PureComponent<CellInnerProps> {
             Component: LayoutComponent = undefined,
             name: layoutType = undefined,
             text: layoutTitle = undefined,
+            allowNeighbours: isDroppable = true,
           } = {},
         } = {},
         content: {
@@ -60,7 +61,7 @@ class Inner extends React.PureComponent<CellInnerProps> {
     } = this.props;
 
     if (rows.length && LayoutComponent) {
-      return (
+      return isDroppable ? (
         <Droppable {...this.props} dropTypes={whitelist}>
           <Draggable
             {...this.props}
@@ -70,6 +71,8 @@ class Inner extends React.PureComponent<CellInnerProps> {
             <Layout {...this.props} />
           </Draggable>
         </Droppable>
+      ) : (
+        <Layout {...this.props} />
       );
     } else if (rows.length) {
       return (

--- a/packages/core/src/service/plugin/classes.ts
+++ b/packages/core/src/service/plugin/classes.ts
@@ -124,6 +124,8 @@ export type LayoutPluginExtraProps<T = any> = {
   createInitialChildren?: () => InitialChildrenDef;
 
   Component?: PluginComponentType<LayoutPluginProps<T>>;
+
+  allowNeighbours?: boolean;
 };
 
 export type LayoutPluginProps<
@@ -495,9 +497,13 @@ export class LayoutPlugin<StateT = any> extends Plugin<
   StateT,
   LayoutPluginExtraProps
 > {
+  /**
+   * @member if true allows to drop near content
+   */
+  allowNeighbours: boolean;
   constructor(config: LayoutPluginConfig<StateT>) {
     super(config);
-    const { createInitialState, createInitialChildren } = config;
+    const { createInitialState, createInitialChildren, allowNeighbours = true } = config;
 
     this.createInitialState = createInitialState
       ? createInitialState.bind(this)
@@ -505,6 +511,7 @@ export class LayoutPlugin<StateT = any> extends Plugin<
     this.createInitialChildren = createInitialChildren
       ? createInitialChildren.bind(this)
       : this.createInitialChildren;
+    this.allowNeighbours = allowNeighbours;
   }
 
   /**

--- a/packages/core/src/service/plugin/classes.ts
+++ b/packages/core/src/service/plugin/classes.ts
@@ -503,7 +503,11 @@ export class LayoutPlugin<StateT = any> extends Plugin<
   allowNeighbours: boolean;
   constructor(config: LayoutPluginConfig<StateT>) {
     super(config);
-    const { createInitialState, createInitialChildren, allowNeighbours = true } = config;
+    const {
+      createInitialState,
+      createInitialChildren,
+      allowNeighbours = true
+    } = config;
 
     this.createInitialState = createInitialState
       ? createInitialState.bind(this)

--- a/packages/core/src/service/plugin/classes.ts
+++ b/packages/core/src/service/plugin/classes.ts
@@ -31,12 +31,14 @@ export type Plugins = {
   layout?: LayoutPluginConfig[];
   content?: ContentPluginConfig[];
   native?: NativeFactory;
+  missingPlugin?: PluginComponentType;
 };
 
 export type PluginsInternal = {
   layout?: LayoutPlugin[];
   content?: ContentPlugin[];
   native?: NativeFactory;
+  missingPlugin?: PluginComponentType;
 };
 
 export type OmitInPluginConfig =
@@ -506,7 +508,7 @@ export class LayoutPlugin<StateT = any> extends Plugin<
     const {
       createInitialState,
       createInitialChildren,
-      allowNeighbours = true
+      allowNeighbours = true,
     } = config;
 
     this.createInitialState = createInitialState

--- a/packages/core/src/service/plugin/index.ts
+++ b/packages/core/src/service/plugin/index.ts
@@ -66,7 +66,14 @@ export default class PluginService {
   /**
    * Instantiate a new PluginService instance. You can provide your own set of content and layout plugins here.
    */
-  constructor({ content = [], layout = [], native }: Plugins = {} as Plugins) {
+  constructor(
+    {
+      content = [],
+      layout = [],
+      native,
+      missingPlugin,
+    }: Plugins = {} as Plugins
+  ) {
     this.plugins = {
       content: [defaultPlugin, ...content].map(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -75,6 +82,7 @@ export default class PluginService {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       layout: layout.map((config: any) => new LayoutPlugin(config)),
       native: native,
+      missingPlugin,
     };
   }
 
@@ -161,7 +169,15 @@ export default class PluginService {
       pluginWrongVersion = this.plugins.layout.find(find(name, '*'));
     }
     return {
-      plugin: plugin || new LayoutPlugin(layoutMissing({ name, version })),
+      plugin:
+        plugin ||
+        new LayoutPlugin(
+          layoutMissing({
+            name,
+            version,
+            Component: this.plugins.missingPlugin,
+          })
+        ),
       pluginWrongVersion,
     };
   };
@@ -179,7 +195,15 @@ export default class PluginService {
       pluginWrongVersion = this.plugins.content.find(find(name, '*'));
     }
     return {
-      plugin: plugin || new ContentPlugin(contentMissing({ name, version })),
+      plugin:
+        plugin ||
+        new ContentPlugin(
+          contentMissing({
+            name,
+            version,
+            Component: this.plugins.missingPlugin,
+          })
+        ),
       pluginWrongVersion,
     };
   };

--- a/packages/core/src/service/plugin/missing.tsx
+++ b/packages/core/src/service/plugin/missing.tsx
@@ -47,8 +47,12 @@ const ContentMissingComponent = (props: ContentPluginProps<unknown>) => (
 export const contentMissing = ({
   name,
   version,
-}: Pick<ContentPluginConfig, 'name' | 'version'>): ContentPluginConfig => ({
-  Component: ContentMissingComponent,
+  Component,
+}: Pick<
+  ContentPluginConfig,
+  'name' | 'version' | 'Component'
+>): ContentPluginConfig => ({
+  Component: Component || ContentMissingComponent,
 
   name,
   version,
@@ -80,8 +84,12 @@ LayoutPluginProps<unknown> & { children: any }) => (
 export const layoutMissing = ({
   name,
   version,
-}: Pick<LayoutPluginConfig, 'name' | 'version'>): LayoutPluginConfig => ({
-  Component: LayoutMissingComponent,
+  Component,
+}: Pick<
+  LayoutPluginConfig,
+  'name' | 'version' | 'Component'
+>): LayoutPluginConfig => ({
+  Component: Component || LayoutMissingComponent,
 
   name,
   version,


### PR DESCRIPTION
This feature is for allowing layout components to not be droppable (not be able to drop near layout)