### PR TITLE
Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Original Library created by [@aeneasr](https://github.com/aeneasr) [@ory](https:
 
 ## In the wild
 
-- [GuestBell Hotel App](https://guest.guestbell.com/demo-hotel/app/property) - Main hotel landing page.
+- [GuestBell Hotel App](https://guest.guestbell.com/demo-hotel/app/property) - React page is used as CMS for hotel landing pages.
 
 ## Sponsored by
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Original Library created by [@aeneasr](https://github.com/aeneasr) [@ory](https:
 [![Follow twitter](https://img.shields.io/badge/follow-twitter-00cc99.svg)](https://twitter.com/_aeneasr)
 [![Follow GitHub](https://img.shields.io/badge/follow-github-00cc99.svg)](https://github.com/arekkas)
 
+## In the wild
+
+- [GuestBell Hotel App](https://guest.guestbell.com/demo-hotel/app/property) - Main hotel landing page.
+
+## Sponsored by
+
+- [GuestBell](https://guestbell.com/) - Customer centric online POS for Hotels and short terms stays.
+
 ## Community
 
 join us on slack: https://reactpage.slack.com


### PR DESCRIPTION
This is a followup to https://github.com/react-page/react-page/issues/767. It appears we all agreed to go forward with it but didn't implement it. I've added our credentials with 2 sections.

"In the wild" Should link directly to places where the react page is used. I could imagine this to be end products as well as popular codepens and so on.

"Sponsored" is for companies and individuals who invest time money or other efforts. All should be sorted alphabetically. 

Feel free to check and add your credentials as well gents.