### PR TITLE
draft: experimental preview

### DIFF
--- a/examples/src/customContentPluginTwitter.tsx
+++ b/examples/src/customContentPluginTwitter.tsx
@@ -15,6 +15,9 @@ export default createContentPlugin<{
       }}
     />
   ),
+  createInitialData: () => ({
+    screenName: 'AlYankovic',
+  }),
   id: 'twitter-timeline',
   title: 'Twitter timeline',
   description: 'A twitter timeline',

--- a/packages/plugins/content/slate/src/index.tsx
+++ b/packages/plugins/content/slate/src/index.tsx
@@ -100,7 +100,7 @@ function plugin<TPlugins extends SlatePluginCollection = DefaultPlugins>(
       children: [
         {
           plugin: plugins.paragraphs.paragraph,
-          children: [''],
+          children: ['Edit text here'],
         },
       ],
     }));

--- a/packages/ui/src/PluginDrawer/Item/index.tsx
+++ b/packages/ui/src/PluginDrawer/Item/index.tsx
@@ -6,6 +6,7 @@ import {
   CellPlugin,
   useInsertNew,
   useDisplayModeReferenceNodeId,
+  useLang,
 } from '@react-page/core';
 
 import * as React from 'react';
@@ -18,6 +19,28 @@ interface ItemProps {
   insert: any;
   translations: Translations;
 }
+
+const Preview: React.FC<{ plugin: CellPlugin }> = ({ plugin }) => {
+  const Component = plugin.Component;
+  const lang = useLang();
+  const data = plugin.createInitialData?.({}) ?? {};
+  return (
+    <div>
+      <Component
+        pluginConfig={plugin}
+        isPreviewMode
+        isEditMode={false}
+        onChange={() => null}
+        readOnly
+        focused={false}
+        state={data}
+        nodeId={null}
+        lang={lang}
+        data={data}
+      ></Component>
+    </div>
+  );
+};
 
 const Item: React.FC<ItemProps> = ({ plugin, insert, translations }) => {
   const title = plugin.title ?? plugin.text;
@@ -48,6 +71,7 @@ const Item: React.FC<ItemProps> = ({ plugin, insert, translations }) => {
           }}
         />
         <ListItemText primary={title} secondary={plugin.description} />
+        <Preview plugin={plugin} />
       </ListItem>
     </Draggable>
   );

--- a/packages/ui/src/PluginDrawer/Item/index.tsx
+++ b/packages/ui/src/PluginDrawer/Item/index.tsx
@@ -1,3 +1,4 @@
+import { Paper } from '@material-ui/core';
 import Avatar from '@material-ui/core/Avatar';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
@@ -25,7 +26,19 @@ const Preview: React.FC<{ plugin: CellPlugin }> = ({ plugin }) => {
   const lang = useLang();
   const data = plugin.createInitialData?.({}) ?? {};
   return (
-    <div>
+    <Paper
+      elevation={2}
+      style={{
+        opacity: 0.9,
+        position: 'fixed',
+        right: '10vw',
+        maxWidth: '30vw',
+        top: '10vw',
+        backgroundColor: 'white',
+        padding: 20,
+        zIndex: 50,
+      }}
+    >
       <Component
         pluginConfig={plugin}
         isPreviewMode
@@ -38,7 +51,7 @@ const Preview: React.FC<{ plugin: CellPlugin }> = ({ plugin }) => {
         lang={lang}
         data={data}
       ></Component>
-    </div>
+    </Paper>
   );
 };
 
@@ -56,23 +69,28 @@ const Item: React.FC<ItemProps> = ({ plugin, insert, translations }) => {
   );
 
   const Draggable = draggable('cell');
-
+  const [hover, setHover] = React.useState(false);
   return (
     <Draggable insert={insert}>
-      <ListItem
-        title="Click to add or drag and drop it somwhere on your page!"
-        className="ory-plugin-drawer-item"
-        onClick={insertIt}
+      <div
+        onMouseOver={() => setHover(true)}
+        onMouseOut={() => setHover(false)}
       >
-        <Avatar
-          children={plugin.IconComponent || title[0]}
-          style={{
-            marginRight: 16,
-          }}
-        />
-        <ListItemText primary={title} secondary={plugin.description} />
-        <Preview plugin={plugin} />
-      </ListItem>
+        <ListItem
+          title="Click to add or drag and drop it somwhere on your page!"
+          className="ory-plugin-drawer-item"
+          onClick={insertIt}
+        >
+          <Avatar
+            children={plugin.IconComponent || title[0]}
+            style={{
+              marginRight: 16,
+            }}
+          />
+          <ListItemText primary={title} secondary={plugin.description} />
+          {hover ? <Preview plugin={plugin} /> : null}
+        </ListItem>
+      </div>
     </Draggable>
   );
 };


### PR DESCRIPTION
thought it would be fun if you would see a preview of the component  when hovering over a plugin in the Plugin drawer.

need small refactoring to also show plugins with children (layout plugins) in a better way