### PR TITLE
feat(ui): ability to override BottomToolbar component

### DIFF
--- a/examples/components/BottomToolbar/CollapseButton.tsx
+++ b/examples/components/BottomToolbar/CollapseButton.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { IconButton, Tooltip } from '@material-ui/core';
+import IconCollapse from '@material-ui/icons/KeyboardArrowDown';
+import IconRestore from '@material-ui/icons/KeyboardArrowUp';
+
+interface CollapseButtonProps {
+  collapsed: boolean;
+  toggleCollapsed(): void;
+}
+
+const CollapseButton: React.FC<CollapseButtonProps> = ({
+  collapsed,
+  toggleCollapsed,
+}) => {
+  return (
+    <Tooltip title={collapsed ? 'Restore Panel' : 'Collapse Panel'}>
+      <IconButton
+        onClick={() => toggleCollapsed()}
+        aria-label="delete"
+        color="default"
+      >
+        {collapsed ? <IconRestore /> : <IconCollapse />}
+      </IconButton>
+    </Tooltip>
+  );
+};
+
+export default React.memo(CollapseButton);

--- a/examples/components/BottomToolbar/Content.tsx
+++ b/examples/components/BottomToolbar/Content.tsx
@@ -1,0 +1,68 @@
+import {
+  Avatar,
+  Grid,
+  IconButton,
+  Tooltip,
+  Typography,
+} from '@material-ui/core';
+import FormatSize from '@material-ui/icons/FormatSize';
+import React from 'react';
+import { usePluginOfCell } from '@react-page/editor';
+import Tools from './Tools';
+import CollapseButton from './CollapseButton';
+
+type Props = {
+  nodeId: string;
+  toggleSize: () => void;
+  collapsed: boolean;
+  toggleCollapsed(): void;
+};
+const Content: React.FC<Props> = ({
+  nodeId,
+  toggleSize,
+  collapsed,
+  toggleCollapsed,
+}) => {
+  const { title, icon } = usePluginOfCell(nodeId) ?? {};
+
+  return (
+    <>
+      <Grid container={true} direction="row" alignItems="center">
+        {icon || title ? (
+          <Grid item={true}>
+            <Avatar
+              children={icon || (title ? title[0] : '')}
+              style={{
+                marginRight: 16,
+              }}
+            />
+          </Grid>
+        ) : null}
+        <Grid item={true}>
+          <Typography variant="subtitle1">{title}</Typography>
+        </Grid>
+        <Grid item={true}>
+          <Tooltip title="Toggle Size">
+            <IconButton
+              onClick={toggleSize}
+              aria-label="toggle Size"
+              color="primary"
+            >
+              <FormatSize />
+            </IconButton>
+          </Tooltip>
+          <CollapseButton
+            collapsed={collapsed}
+            toggleCollapsed={toggleCollapsed}
+          />
+        </Grid>
+
+        <Grid item={true} style={{ marginLeft: 'auto' }}>
+          <Tools nodeId={nodeId} />
+        </Grid>
+      </Grid>
+    </>
+  );
+};
+
+export default React.memo(Content);

--- a/examples/components/BottomToolbar/DraftSwitch.tsx
+++ b/examples/components/BottomToolbar/DraftSwitch.tsx
@@ -1,0 +1,47 @@
+import { FormControlLabel, Switch, Tooltip } from '@material-ui/core';
+import VisibleIcon from '@material-ui/icons/Visibility';
+import NonVisibleIcon from '@material-ui/icons/VisibilityOff';
+import React from 'react';
+import { useCellProps, useLang, useSetDraft } from '@react-page/editor';
+
+const DraftSwitch = ({ nodeId, lang }: { nodeId: string; lang?: string }) => {
+  const cell = useCellProps(nodeId, (c) => ({
+    isDraft: c.isDraft,
+    isDraftI18n: c.isDraftI18n,
+  }));
+  const setDraft = useSetDraft(nodeId);
+  const currentLang = useLang();
+  if (!cell) {
+    return null;
+  }
+  const theLang = lang ?? currentLang;
+  const hasI18n = Boolean(cell.isDraftI18n);
+  const isDraft = cell?.isDraftI18n?.[theLang] ?? cell?.isDraft; // fallback to legacy
+  const title = isDraft ? 'Content is hidden' : 'Content is visible';
+  return cell ? (
+    <Tooltip title={title + (hasI18n ? ' in ' + theLang : '')}>
+      <FormControlLabel
+        style={{ marginRight: 5 }}
+        labelPlacement="start"
+        control={
+          <Switch
+            color="primary"
+            checked={!isDraft}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setDraft(!e.target.checked, theLang);
+            }}
+          />
+        }
+        label={
+          isDraft ? (
+            <NonVisibleIcon style={{ marginTop: 5 }} />
+          ) : (
+            <VisibleIcon style={{ marginTop: 5 }} />
+          )
+        }
+      />
+    </Tooltip>
+  ) : null;
+};
+
+export default DraftSwitch;

--- a/examples/components/BottomToolbar/DuplicateButton.tsx
+++ b/examples/components/BottomToolbar/DuplicateButton.tsx
@@ -1,0 +1,18 @@
+import { IconButton, Tooltip } from '@material-ui/core';
+import Icon from '@material-ui/icons/FileCopy';
+import React from 'react';
+import { useDuplicateCell } from '@react-page/editor';
+
+const DuplicateButton: React.FC<{ nodeId: string }> = ({ nodeId }) => {
+  const duplicateCell = useDuplicateCell(nodeId);
+
+  return (
+    <Tooltip title="Duplicate Plugin">
+      <IconButton onClick={duplicateCell} aria-label="delete" color="default">
+        <Icon />
+      </IconButton>
+    </Tooltip>
+  );
+};
+
+export default DuplicateButton;

--- a/examples/components/BottomToolbar/SelectParentButton.tsx
+++ b/examples/components/BottomToolbar/SelectParentButton.tsx
@@ -1,0 +1,26 @@
+import IconButton from '@material-ui/core/IconButton';
+import VerticalAlignTopIcon from '@material-ui/icons/VerticalAlignTop';
+
+import React from 'react';
+import { useFocusCell, useParentCellId } from '@react-page/editor';
+
+const SelectParentButton: React.FC<{
+  nodeId: string;
+}> = ({ nodeId }) => {
+  const parentCellId = useParentCellId(nodeId);
+
+  const focusParent = useFocusCell(parentCellId);
+
+  return parentCellId ? (
+    <IconButton
+      className="bottomToolbar__selectParentButton"
+      onClick={() => focusParent()}
+      color="default"
+      title="Select parent"
+    >
+      <VerticalAlignTopIcon />
+    </IconButton>
+  ) : null;
+};
+
+export default SelectParentButton;

--- a/examples/components/BottomToolbar/Tools.tsx
+++ b/examples/components/BottomToolbar/Tools.tsx
@@ -1,0 +1,35 @@
+import { IconButton, Tooltip } from '@material-ui/core';
+import Delete from '@material-ui/icons/Delete';
+
+import React from 'react';
+import { useRemoveCell } from '@react-page/editor';
+import DraftSwitch from './DraftSwitch';
+import DuplicateButton from './DuplicateButton';
+import SelectParentButton from './SelectParentButton';
+
+type ToolsProps = {
+  nodeId: string;
+};
+
+const Tools: React.FC<ToolsProps> = ({ nodeId }) => {
+  const removeCell = useRemoveCell(nodeId);
+  return (
+    <div style={{ display: 'flex', alignItems: 'center' }}>
+      <DraftSwitch nodeId={nodeId} />
+      <DuplicateButton nodeId={nodeId} />
+      <SelectParentButton nodeId={nodeId} />
+
+      <Tooltip title="Remove Plugin">
+        <IconButton
+          onClick={() => removeCell()}
+          aria-label="delete"
+          color="secondary"
+        >
+          <Delete />
+        </IconButton>
+      </Tooltip>
+    </div>
+  );
+};
+
+export default React.memo(Tools);

--- a/examples/components/BottomToolbar/index.tsx
+++ b/examples/components/BottomToolbar/index.tsx
@@ -1,0 +1,100 @@
+import { ThemeProvider, darkTheme, EditorProps } from '@react-page/editor';
+import { Divider, Portal } from '@material-ui/core';
+import Drawer from '@material-ui/core/Drawer';
+import React from 'react';
+import Content from './Content';
+
+type BottomToolbarComponent = EditorProps['components']['BottomToolbar'];
+
+const darkBlack = 'rgba(0, 0, 0, 0.87)';
+const bright = 'rgba(255,255,255, 0.98)';
+const brightBorder = 'rgba(0, 0, 0, 0.12)';
+const SIZES = [1, 0.8, 0.6, 1.2];
+let lastSize = SIZES[0]; // poor mans redux
+
+const BottomToolbar: BottomToolbarComponent = ({
+  open = false,
+  children,
+  className,
+  dark = false,
+  theme,
+  anchor = 'bottom',
+  nodeId,
+}) => {
+  const [size, setSize] = React.useState(lastSize);
+  const toggleSize = React.useCallback(() => {
+    const newSize = SIZES[(SIZES.indexOf(size) + 1) % SIZES.length];
+    setSize(newSize);
+    // poor man's redux
+    lastSize = newSize;
+  }, [size, setSize]);
+
+  const [collapsed, setCollapsed] = React.useState(false);
+  const toggleCollapsed = React.useCallback(() => {
+    setCollapsed((collapsed) => !collapsed);
+  }, [setCollapsed]);
+
+  return (
+    <Portal>
+      <ThemeProvider theme={theme ? theme : dark ? darkTheme : null}>
+        <Drawer
+          SlideProps={{
+            mountOnEnter: true,
+            unmountOnExit: true,
+          }}
+          variant="persistent"
+          className={className}
+          open={open}
+          anchor={anchor}
+          PaperProps={{
+            style: {
+              zIndex: 10,
+              backgroundColor: 'transparent',
+              border: 'none',
+              overflow: 'visible',
+              pointerEvents: 'none',
+            },
+          }}
+        >
+          <div
+            style={{
+              pointerEvents: 'all',
+              border: `${dark ? darkBlack : brightBorder} 1px solid`,
+              borderRadius: '4px 4px 0 0',
+              backgroundColor: dark ? darkBlack : bright,
+              padding: '12px 24px',
+
+              margin: 'auto',
+              boxShadow: '0px 1px 8px -1px rgba(0,0,0,0.4)',
+              position: 'relative',
+              minWidth: '50vw',
+              maxWidth: 'calc(100vw - 220px)',
+              transformOrigin: 'bottom',
+              transform: `scale(${size})`,
+              transition: '0.3s',
+            }}
+          >
+            {collapsed ? null : children}
+            <Divider
+              style={{
+                marginLeft: -24,
+                marginRight: -24,
+                marginTop: 12,
+                marginBottom: 12,
+              }}
+            />
+
+            <Content
+              nodeId={nodeId}
+              toggleSize={toggleSize}
+              collapsed={collapsed}
+              toggleCollapsed={toggleCollapsed}
+            />
+          </div>
+        </Drawer>
+      </ThemeProvider>
+    </Portal>
+  );
+};
+
+export default React.memo(BottomToolbar);

--- a/examples/pages/examples/customToolbar.tsx
+++ b/examples/pages/examples/customToolbar.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import Editor, { Value } from '@react-page/editor';
+import slate from '@react-page/plugins-slate';
+import image from '@react-page/plugins-image';
+import BottomToolbar from '../../components/BottomToolbar';
+
+const cellPlugins = [slate(), image];
+
+// Custom bottom toolbar with collapse/restore functionality.
+const CustomToolbar = () => {
+  const [value] = React.useState<Value>(null);
+
+  const components = React.useMemo(
+    () => ({ BottomToolbar: BottomToolbar }),
+    []
+  );
+
+  return (
+    <>
+      <Editor cellPlugins={cellPlugins} value={value} components={components} />
+    </>
+  );
+};
+
+export default CustomToolbar;

--- a/packages/editor/src/core/Provider/index.tsx
+++ b/packages/editor/src/core/Provider/index.tsx
@@ -159,7 +159,8 @@ const Provider: React.FC<ProviderProps> = ({
     editModeResizeHandle,
     languages,
     JSON.stringify(childConstraints ?? {}), // its an object, we prevent unnecessary rerenders by stringify it
-    components,
+    ...Object.keys(components ?? {}),
+    ...Object.values(components ?? {}), // minimize unnecessary rerenders by forcing shallow comparison of "components" object
   ]);
 
   return (

--- a/packages/editor/src/core/Provider/index.tsx
+++ b/packages/editor/src/core/Provider/index.tsx
@@ -51,6 +51,7 @@ const Provider: React.FC<ProviderProps> = ({
   editModeResizeHandle,
   languages,
   pluginsWillChange,
+  components,
   store: passedStore,
   middleware = [],
 }) => {
@@ -149,6 +150,7 @@ const Provider: React.FC<ProviderProps> = ({
       editModeResizeHandle,
       languages,
       childConstraints,
+      components,
     };
   }, [
     pluginsWillChange && cellPlugins,
@@ -156,7 +158,8 @@ const Provider: React.FC<ProviderProps> = ({
     allowResizeInEditMode,
     editModeResizeHandle,
     languages,
-    JSON.stringify(childConstraints ?? {}), // its an object, we prevent unessesary rerenders by stringify it
+    JSON.stringify(childConstraints ?? {}), // its an object, we prevent unnecessary rerenders by stringify it
+    components,
   ]);
 
   return (

--- a/packages/editor/src/core/components/Cell/PluginComponent/index.tsx
+++ b/packages/editor/src/core/components/Cell/PluginComponent/index.tsx
@@ -10,6 +10,7 @@ import {
   useIsPreviewMode,
   useLang,
   useRemoveCell,
+  useOptions,
 } from '../../hooks';
 import PluginMissing from '../PluginMissing';
 
@@ -31,6 +32,8 @@ const PluginComponent: React.FC<{ nodeId: string; hasChildren: boolean }> = ({
   const Component = plugin?.Renderer ?? PluginMissing;
   const Provider = plugin?.Provider ?? DefaultProvider;
   const remove = useRemoveCell(nodeId);
+
+  const Toolbar = useOptions().components?.BottomToolbar ?? BottomToolbar;
 
   const componentProps: CellPluginComponentProps<unknown> = {
     nodeId,
@@ -69,7 +72,7 @@ const PluginComponent: React.FC<{ nodeId: string; hasChildren: boolean }> = ({
         >
           <Component {...componentProps}>{children}</Component>
         </div>
-        <BottomToolbar
+        <Toolbar
           nodeId={nodeId}
           open={focused && isEditMode}
           dark={plugin?.controls?.dark}
@@ -79,7 +82,7 @@ const PluginComponent: React.FC<{ nodeId: string; hasChildren: boolean }> = ({
           >
             {controlsElement}
           </div>
-        </BottomToolbar>
+        </Toolbar>
       </>
     </Provider>
   );

--- a/packages/editor/src/core/types/components.ts
+++ b/packages/editor/src/core/types/components.ts
@@ -1,0 +1,11 @@
+import { BottomToolbarProps } from '../../ui/BottomToolbar/types';
+
+/**
+ * Internal component overrides for the editor.
+ */
+export type Components = {
+  /**
+   * BottomToolbar used for rendering plugin controls.
+   */
+  BottomToolbar?: React.ComponentType<BottomToolbarProps>;
+};

--- a/packages/editor/src/core/types/node.ts
+++ b/packages/editor/src/core/types/node.ts
@@ -2,6 +2,7 @@ import { CellPlugin } from './plugins';
 
 import { Languages } from '../EditorStore';
 import { ChildConstraints } from './constraints';
+import { Components } from './components';
 
 export type I18nField<T> = {
   [lang: string]: T;
@@ -136,4 +137,9 @@ export type Options = {
    * Leave this to false if you don't want to change plugins while editor is mounted.
    */
   pluginsWillChange?: boolean;
+
+  /**
+   * Internal component overrides.
+   */
+  components?: Components;
 } & SimplifiedModesProps;

--- a/packages/editor/src/editor/EditableEditor.tsx
+++ b/packages/editor/src/editor/EditableEditor.tsx
@@ -38,6 +38,7 @@ const EditableEditor: React.FC<EditableEditorProps> = ({
   allowResizeInEditMode = true,
   editModeResizeHandle,
   childConstraints,
+  components,
 }) => {
   const theValue = value || createEmptyState();
   return (
@@ -56,6 +57,7 @@ const EditableEditor: React.FC<EditableEditorProps> = ({
       blurGateDisabled={blurGateDisabled}
       blurGateDefaultMode={defaultDisplayMode}
       childConstraints={childConstraints}
+      components={components}
     >
       <StickyWrapper>
         {(stickyNess) => (

--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -12,6 +12,9 @@ import { migrateValue } from './core/migrations/migrate';
 import deepEquals from './core/utils/deepEquals';
 export { AutoForm, AutoFields };
 
+import ThemeProvider, { darkTheme } from './ui/ThemeProvider';
+export { ThemeProvider, darkTheme };
+
 export * from './ui/ColorPicker';
 export * from './ui/ImageUpload';
 export { lazyLoad };


### PR DESCRIPTION
## Ability to override BottomToolbar component

Add an ability to override certain internal components starting with BottomToolbar.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Closing issues

closes #909
