### PR TITLE
fet(ui): cell spacing

### DIFF
--- a/examples/pages/examples/cellSpacing.tsx
+++ b/examples/pages/examples/cellSpacing.tsx
@@ -19,8 +19,8 @@ interface CellSpacingState {
   readOnly?: boolean;
   outlineEditor?: boolean;
   outlineCells?: boolean;
-  cellSpacingX?: string;
-  cellSpacingY?: string;
+  cellSpacingX?: number;
+  cellSpacingY?: number;
 }
 
 // Remove samples stylesheet cell padding and optionally outline cell and editor boundaries.
@@ -44,8 +44,8 @@ export default function CellSpacing() {
     value: cellSpacingDemo,
     outlineEditor: true,
     outlineCells: true,
-    cellSpacingX: '10',
-    cellSpacingY: '10',
+    cellSpacingX: 10,
+    cellSpacingY: 10,
   });
 
   const style = React.useMemo(
@@ -59,8 +59,8 @@ export default function CellSpacing() {
       outlineEditor: { type: 'boolean', title: 'Outline the Editor in Green' },
       outlineCells: { type: 'boolean', title: 'Outline Cells in Red' },
       readOnly: { type: 'boolean', title: 'Read Only' },
-      cellSpacingX: { type: 'string', title: 'Horizontal Cell Spacing' },
-      cellSpacingY: { type: 'string', title: 'Vertical Cell Spacing' },
+      cellSpacingX: { type: 'number', title: 'Horizontal Cell Spacing' },
+      cellSpacingY: { type: 'number', title: 'Vertical Cell Spacing' },
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any);
@@ -107,9 +107,7 @@ export default function CellSpacing() {
           cellPlugins={cellPlugins}
           value={state.value}
           onChange={(value) => setState((s) => ({ ...s, value }))}
-          // let's also test our ability to survive non-numbers
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          cellSpacing={[state.cellSpacingX as any, state.cellSpacingY as any]}
+          cellSpacing={{ x: state.cellSpacingX, y: state.cellSpacingY }}
         />
       </div>
     </PageLayout>

--- a/examples/pages/examples/cellSpacing.tsx
+++ b/examples/pages/examples/cellSpacing.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+
+// The editor core
+import Editor, { Value } from '@react-page/editor';
+
+// import the main css, uncomment this: (this is commented in the example because of https://github.com/vercel/next.js/issues/19717)
+// import '@react-page/editor/lib/index.css';
+
+// The rich text area plugin
+import slate from '@react-page/plugins-slate';
+// image
+import image from '@react-page/plugins-image';
+// background
+import background from '@react-page/plugins-background';
+import PageLayout from '../../components/PageLayout';
+
+// Stylesheets for the rich text area plugin
+// uncomment this
+//import '@react-page/plugins-slate/lib/index.css';
+
+// Stylesheets for the imagea plugin
+//import '@react-page/plugins-image/lib/index.css';
+
+// Define which plugins we want to use.
+const cellPlugins = [slate(), image, background({})];
+
+// Remove samples stylesheet cell padding, highlight cell and editor boundaries to demonstrate the cell spacing.
+const styles = `
+.react-page-cell-inner-leaf {
+  padding: 0;
+}
+.react-page-cell-inner > div {
+  outline: 1px solid red;
+}
+.react-page-editable {
+  outline: 1px solid green;
+}
+`;
+
+export default function SimpleExample() {
+  const [value, setValue] = useState<Value>(null);
+
+  return (
+    <PageLayout>
+      <style dangerouslySetInnerHTML={{ __html: styles }} />
+      <Editor
+        cellPlugins={cellPlugins}
+        value={value}
+        onChange={setValue}
+        cellSpacing={20}
+      />
+    </PageLayout>
+  );
+}

--- a/examples/pages/examples/cellSpacing.tsx
+++ b/examples/pages/examples/cellSpacing.tsx
@@ -7,14 +7,16 @@ import Editor, {
 } from '@react-page/editor';
 import slate from '@react-page/plugins-slate';
 import image from '@react-page/plugins-image';
-import background from '@react-page/plugins-background';
+import customLayout from '../../plugins/customLayoutPluginWithCellSpacing';
 import PageLayout from '../../components/PageLayout';
+import { cellSpacingDemo } from '../../sampleContents/cellSpacing';
 
 // Define which plugins we want to use.
-const cellPlugins = [slate(), image, background({})];
+const cellPlugins = [slate(), image, customLayout];
 
 interface CellSpacingState {
   value?: Value;
+  readOnly?: boolean;
   outlineEditor?: boolean;
   outlineCells?: boolean;
   cellSpacingX?: string;
@@ -26,11 +28,12 @@ function styles(state: CellSpacingState) {
   let styles = '.react-page-cell-inner-leaf { padding: 0; }';
 
   if (state.outlineCells) {
-    styles += '.react-page-cell-inner > div { outline: 1px solid red; }';
+    styles +=
+      '.react-page-cell-inner:not(.react-page-row) > div { outline: 1px solid red; }';
   }
 
   if (state.outlineEditor) {
-    styles += '.react-page-editable { outline: 1px solid green; }';
+    styles += '.editor { outline: 1px solid green; }';
   }
 
   return styles;
@@ -38,6 +41,9 @@ function styles(state: CellSpacingState) {
 
 export default function CellSpacing() {
   const [state, setState] = React.useState<CellSpacingState>({
+    value: cellSpacingDemo,
+    outlineEditor: true,
+    outlineCells: true,
     cellSpacingX: '10',
     cellSpacingY: '10',
   });
@@ -52,6 +58,7 @@ export default function CellSpacing() {
     properties: {
       outlineEditor: { type: 'boolean', title: 'Outline the Editor in Green' },
       outlineCells: { type: 'boolean', title: 'Outline Cells in Red' },
+      readOnly: { type: 'boolean', title: 'Read Only' },
       cellSpacingX: { type: 'string', title: 'Horizontal Cell Spacing' },
       cellSpacingY: { type: 'string', title: 'Vertical Cell Spacing' },
     },
@@ -79,23 +86,32 @@ export default function CellSpacing() {
         >
           <div
             style={{
-              columnCount: 3,
-              columnGap: 48,
+              display: 'flex',
+              maxWidth: 600,
             }}
           >
-            <AutoFields />
+            <AutoFields
+              fields={['readOnly', 'outlineEditor', 'outlineCells']}
+            />
+            <AutoFields fields={['cellSpacingX', 'cellSpacingY']} />
           </div>
         </AutoForm>
       </div>
 
-      <Editor
-        cellPlugins={cellPlugins}
-        value={state.value}
-        onChange={(value) => setState((s) => ({ ...s, value }))}
-        // let's also test our ability to survive non-numbers
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        cellSpacing={[state.cellSpacingX as any, state.cellSpacingY as any]}
-      />
+      <div
+        className="editor"
+        style={{ display: 'flex', flexDirection: 'column' }}
+      >
+        <Editor
+          readOnly={state.readOnly}
+          cellPlugins={cellPlugins}
+          value={state.value}
+          onChange={(value) => setState((s) => ({ ...s, value }))}
+          // let's also test our ability to survive non-numbers
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          cellSpacing={[state.cellSpacingX as any, state.cellSpacingY as any]}
+        />
+      </div>
     </PageLayout>
   );
 }

--- a/examples/plugins/customLayoutPluginWithCellSpacing.tsx
+++ b/examples/plugins/customLayoutPluginWithCellSpacing.tsx
@@ -1,0 +1,64 @@
+import { CellPlugin } from '@react-page/editor';
+import React from 'react';
+
+const customLayoutPlugin: CellPlugin<{
+  backgroundColor: string;
+  paddingX: number;
+  paddingY: number;
+  cellSpacingOverride?: boolean;
+  cellSpacingX: number;
+  cellSpacingY: number;
+}> = {
+  Renderer: ({ children, data }) => (
+    <div
+      style={{
+        height: '100%',
+        boxSizing: 'border-box',
+        backgroundColor: data.backgroundColor,
+        padding: `${data.paddingY}px ${data.paddingX}px`,
+      }}
+    >
+      {children}
+    </div>
+  ),
+
+  cellSpacing: (data) =>
+    data.cellSpacingOverride ? [data.cellSpacingX, data.cellSpacingY] : null,
+
+  createInitialData: () => ({
+    backgroundColor: '#ffeeaa',
+    paddingX: 12,
+    paddingY: 12,
+    cellSpacingOverride: false,
+    cellSpacingX: 10,
+    cellSpacingY: 10,
+  }),
+
+  id: 'custom-layout-plugin-with-cell-spacing',
+  title: 'Background with Cell Spacing',
+  description: 'Custom layout plugin with cell spacing support',
+  version: 1,
+
+  controls: {
+    type: 'autoform',
+    schema: {
+      required: ['backgroundColor'],
+      properties: {
+        backgroundColor: { type: 'string', title: 'Background Color' },
+        paddingX: { type: 'number', title: 'Horizontal Padding' },
+        paddingY: { type: 'number', title: 'Vertical Padding' },
+        cellSpacingOverride: {
+          type: 'boolean',
+          title: 'Override Cell Spacing',
+        },
+        cellSpacingX: {
+          type: 'number',
+          title: 'Horizontal Cell Spacing',
+        },
+        cellSpacingY: { type: 'number', title: 'Vertical Cell Spacing' },
+      },
+    },
+  },
+};
+
+export default customLayoutPlugin;

--- a/examples/plugins/customLayoutPluginWithCellSpacing.tsx
+++ b/examples/plugins/customLayoutPluginWithCellSpacing.tsx
@@ -23,7 +23,9 @@ const customLayoutPlugin: CellPlugin<{
   ),
 
   cellSpacing: (data) =>
-    data.cellSpacingOverride ? [data.cellSpacingX, data.cellSpacingY] : null,
+    data.cellSpacingOverride
+      ? { x: data.cellSpacingX, y: data.cellSpacingY }
+      : null,
 
   createInitialData: () => ({
     backgroundColor: '#ffeeaa',

--- a/examples/sampleContents/cellSpacing.tsx
+++ b/examples/sampleContents/cellSpacing.tsx
@@ -1,0 +1,484 @@
+import type { Value } from '@react-page/editor';
+
+export const cellSpacingDemo: Value = {
+  id: 'c1uxgo',
+  version: 1,
+  rows: [
+    {
+      id: 'l09c73',
+      cells: [
+        {
+          id: '3pkvwh',
+          size: 6,
+          plugin: {
+            id: 'ory/editor/core/content/slate',
+            version: 1,
+          },
+          dataI18n: {
+            default: {
+              slate: [
+                {
+                  type: 'PARAGRAPH/PARAGRAPH',
+                  children: [
+                    {
+                      text:
+                        'Top level layout that uses global cell spacing settings',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          rows: [],
+        },
+        {
+          id: 'y0zafy',
+          size: 6,
+          rows: [
+            {
+              id: 'slc8rh',
+              cells: [
+                {
+                  id: 'mmjkz1',
+                  size: 12,
+                  plugin: {
+                    id: 'ory/editor/core/content/slate',
+                    version: 1,
+                  },
+                  dataI18n: {
+                    default: {
+                      slate: [
+                        {
+                          type: 'PARAGRAPH/PARAGRAPH',
+                          children: [
+                            {
+                              text: 'Lorem Ipsum',
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  },
+                  rows: [],
+                },
+              ],
+            },
+            {
+              id: 'qe32q9',
+              cells: [
+                {
+                  id: 'dl80vv',
+                  size: 6,
+                  plugin: {
+                    id: 'ory/editor/core/content/slate',
+                    version: 1,
+                  },
+                  dataI18n: {
+                    default: {
+                      slate: [
+                        {
+                          type: 'PARAGRAPH/PARAGRAPH',
+                          children: [
+                            {
+                              text: 'Lorem Ipsum',
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  },
+                  rows: [],
+                },
+                {
+                  id: '8xymvk',
+                  size: 6,
+                  plugin: {
+                    id: 'ory/editor/core/content/slate',
+                    version: 1,
+                  },
+                  dataI18n: {
+                    default: {
+                      slate: [
+                        {
+                          type: 'PARAGRAPH/PARAGRAPH',
+                          children: [
+                            {
+                              text: 'Lorem Ipsum',
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  },
+                  rows: [],
+                },
+              ],
+            },
+            {
+              id: 'v55yqx',
+              cells: [
+                {
+                  id: 'ha4hiq',
+                  size: 12,
+                  plugin: {
+                    id: 'ory/editor/core/content/slate',
+                    version: 1,
+                  },
+                  dataI18n: {
+                    default: {
+                      slate: [
+                        {
+                          type: 'PARAGRAPH/PARAGRAPH',
+                          children: [
+                            {
+                              text: 'Lorem Ipsum',
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  },
+                  rows: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: '0ni7v8',
+      cells: [
+        {
+          id: 'umiqg2',
+          size: 12,
+          plugin: {
+            id: 'custom-layout-plugin-with-cell-spacing',
+            version: 1,
+          },
+          dataI18n: {
+            default: {
+              backgroundColor: '#ffeeaa',
+              paddingX: 12,
+              paddingY: 12,
+              cellSpacingOverride: true,
+              cellSpacingX: 20,
+              cellSpacingY: 20,
+            },
+          },
+          rows: [
+            {
+              id: 'bx0cd7',
+              cells: [
+                {
+                  id: 'tagh46',
+                  size: 6,
+                  plugin: {
+                    id: 'ory/editor/core/content/slate',
+                    version: 1,
+                  },
+                  dataI18n: {
+                    default: {
+                      slate: [
+                        {
+                          type: 'PARAGRAPH/PARAGRAPH',
+                          children: [
+                            {
+                              text:
+                                'Layout plugin with custom padding and cell spacing overrides',
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  },
+                  rows: [],
+                },
+                {
+                  id: 'fvrrm1',
+                  size: 6,
+                  rows: [
+                    {
+                      id: 'zvjmqy',
+                      cells: [
+                        {
+                          id: '759xh9',
+                          size: 12,
+                          plugin: {
+                            id: 'ory/editor/core/content/slate',
+                            version: 1,
+                          },
+                          dataI18n: {
+                            default: {
+                              slate: [
+                                {
+                                  type: 'PARAGRAPH/PARAGRAPH',
+                                  children: [
+                                    {
+                                      text: 'Lorem Ipsum',
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          },
+                          rows: [],
+                        },
+                      ],
+                    },
+                    {
+                      id: 'o5nku6',
+                      cells: [
+                        {
+                          id: 'gss6fg',
+                          size: 6,
+                          plugin: {
+                            id: 'ory/editor/core/content/slate',
+                            version: 1,
+                          },
+                          dataI18n: {
+                            default: {
+                              slate: [
+                                {
+                                  type: 'PARAGRAPH/PARAGRAPH',
+                                  children: [
+                                    {
+                                      text: 'Lorem Ipsum',
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          },
+                          rows: [],
+                        },
+                        {
+                          id: 'q5vmp1',
+                          size: 6,
+                          plugin: {
+                            id: 'ory/editor/core/content/slate',
+                            version: 1,
+                          },
+                          dataI18n: {
+                            default: {
+                              slate: [
+                                {
+                                  type: 'PARAGRAPH/PARAGRAPH',
+                                  children: [
+                                    {
+                                      text: 'Lorem Ipsum',
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          },
+                          rows: [],
+                        },
+                      ],
+                    },
+                    {
+                      id: 'plcf90',
+                      cells: [
+                        {
+                          id: 'rc3y65',
+                          size: 12,
+                          plugin: {
+                            id: 'ory/editor/core/content/slate',
+                            version: 1,
+                          },
+                          dataI18n: {
+                            default: {
+                              slate: [
+                                {
+                                  type: 'PARAGRAPH/PARAGRAPH',
+                                  children: [
+                                    {
+                                      text: 'Lorem Ipsum',
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          },
+                          rows: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              id: 'w7lf7g',
+              cells: [
+                {
+                  id: 'adxf4r',
+                  size: 12,
+                  plugin: {
+                    id: 'custom-layout-plugin-with-cell-spacing',
+                    version: 1,
+                  },
+                  dataI18n: {
+                    default: {
+                      backgroundColor: '#f7cf2e',
+                      paddingX: 0,
+                      paddingY: 0,
+                      cellSpacingOverride: true,
+                      cellSpacingX: 30,
+                      cellSpacingY: 30,
+                    },
+                  },
+                  rows: [
+                    {
+                      id: 'hkelwj',
+                      cells: [
+                        {
+                          id: 'tv3lki',
+                          size: 6,
+                          plugin: {
+                            id: 'ory/editor/core/content/slate',
+                            version: 1,
+                          },
+                          dataI18n: {
+                            default: {
+                              slate: [
+                                {
+                                  type: 'PARAGRAPH/PARAGRAPH',
+                                  children: [
+                                    {
+                                      text:
+                                        'Nested layout plugin with no padding and its own cell spacing overrides',
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          },
+                          rows: [],
+                        },
+                        {
+                          id: '1afdrz',
+                          size: 6,
+                          rows: [
+                            {
+                              id: 'hqghus',
+                              cells: [
+                                {
+                                  id: '9kxp9i',
+                                  size: 12,
+                                  plugin: {
+                                    id: 'ory/editor/core/content/slate',
+                                    version: 1,
+                                  },
+                                  dataI18n: {
+                                    default: {
+                                      slate: [
+                                        {
+                                          type: 'PARAGRAPH/PARAGRAPH',
+                                          children: [
+                                            {
+                                              text: 'Lorem Ipsum',
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                    },
+                                  },
+                                  rows: [],
+                                },
+                              ],
+                            },
+                            {
+                              id: 'j9barl',
+                              cells: [
+                                {
+                                  id: 'oswsvd',
+                                  size: 6,
+                                  plugin: {
+                                    id: 'ory/editor/core/content/slate',
+                                    version: 1,
+                                  },
+                                  dataI18n: {
+                                    default: {
+                                      slate: [
+                                        {
+                                          type: 'PARAGRAPH/PARAGRAPH',
+                                          children: [
+                                            {
+                                              text: 'Lorem Ipsum',
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                    },
+                                  },
+                                  rows: [],
+                                },
+                                {
+                                  id: 'yv3say',
+                                  size: 6,
+                                  plugin: {
+                                    id: 'ory/editor/core/content/slate',
+                                    version: 1,
+                                  },
+                                  dataI18n: {
+                                    default: {
+                                      slate: [
+                                        {
+                                          type: 'PARAGRAPH/PARAGRAPH',
+                                          children: [
+                                            {
+                                              text: 'Lorem Ipsum',
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                    },
+                                  },
+                                  rows: [],
+                                },
+                              ],
+                            },
+                            {
+                              id: 'c2jgv8',
+                              cells: [
+                                {
+                                  id: 'gbddws',
+                                  size: 12,
+                                  plugin: {
+                                    id: 'ory/editor/core/content/slate',
+                                    version: 1,
+                                  },
+                                  dataI18n: {
+                                    default: {
+                                      slate: [
+                                        {
+                                          type: 'PARAGRAPH/PARAGRAPH',
+                                          children: [
+                                            {
+                                              text: 'Lorem Ipsum',
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                    },
+                                  },
+                                  rows: [],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/packages/editor/src/core/Provider/index.tsx
+++ b/packages/editor/src/core/Provider/index.tsx
@@ -163,7 +163,7 @@ const Provider: React.FC<ProviderProps> = ({
     JSON.stringify(childConstraints ?? {}), // its an object, we prevent unnecessary rerenders by stringify it
     ...Object.keys(components ?? {}),
     ...Object.values(components ?? {}), // minimize unnecessary rerenders by forcing shallow comparison of "components" object
-    cellSpacing,
+    JSON.stringify(cellSpacing ?? []),
   ]);
 
   return (

--- a/packages/editor/src/core/Provider/index.tsx
+++ b/packages/editor/src/core/Provider/index.tsx
@@ -52,6 +52,7 @@ const Provider: React.FC<ProviderProps> = ({
   languages,
   pluginsWillChange,
   components,
+  cellSpacing,
   store: passedStore,
   middleware = [],
 }) => {
@@ -151,6 +152,7 @@ const Provider: React.FC<ProviderProps> = ({
       languages,
       childConstraints,
       components,
+      cellSpacing,
     };
   }, [
     pluginsWillChange && cellPlugins,
@@ -161,6 +163,7 @@ const Provider: React.FC<ProviderProps> = ({
     JSON.stringify(childConstraints ?? {}), // its an object, we prevent unnecessary rerenders by stringify it
     ...Object.keys(components ?? {}),
     ...Object.values(components ?? {}), // minimize unnecessary rerenders by forcing shallow comparison of "components" object
+    cellSpacing,
   ]);
 
   return (

--- a/packages/editor/src/core/components/Cell/Droppable/index.tsx
+++ b/packages/editor/src/core/components/Cell/Droppable/index.tsx
@@ -16,6 +16,8 @@ import {
   useIsLayoutMode,
   useNodeHoverPosition,
   useOptions,
+  useCellHasPlugin,
+  useCellSpacing,
 } from '../../hooks';
 import { onDrop, onHover } from './helper/dnd';
 
@@ -90,6 +92,10 @@ const Droppable: React.FC<{ nodeId: string; isLeaf?: boolean }> = (props) => {
   const attach = useCellDrop(props.nodeId);
   const hoverPosition = useNodeHoverPosition(props.nodeId);
   const options = useOptions();
+  const hasPlugin = useCellHasPlugin(props.nodeId);
+  const [, cellSpacingY] = useCellSpacing();
+  const needVerticalMargin = !props.isLeaf && !hasPlugin;
+
   if (!(isLayoutMode || isInsertMode) && !options.allowMoveInEditMode) {
     return (
       <div className={'react-page-cell-droppable-container'}>
@@ -104,12 +110,23 @@ const Droppable: React.FC<{ nodeId: string; isLeaf?: boolean }> = (props) => {
       style={{
         height: '100%',
       }}
-      className={classNames('react-page-cell-droppable', {
-        'react-page-cell-droppable-is-over-current': hoverPosition,
-        [`react-page-cell-droppable-is-over-${hoverPosition}`]: hoverPosition,
-        'react-page-cell-droppable-leaf': props.isLeaf,
-      })}
+      className="react-page-cell-droppable"
     >
+      <div
+        style={{
+          position: 'absolute',
+          pointerEvents: 'none',
+          top: needVerticalMargin ? `${cellSpacingY / 2}px` : 0,
+          left: 0,
+          bottom: needVerticalMargin ? `${cellSpacingY / 2}px` : 0,
+          right: 0,
+        }}
+        className={classNames({
+          'react-page-cell-droppable-is-over-current': hoverPosition,
+          [`react-page-cell-droppable-is-over-${hoverPosition}`]: hoverPosition,
+          'react-page-cell-droppable-leaf': props.isLeaf,
+        })}
+      />
       {props.children}
     </div>
   );

--- a/packages/editor/src/core/components/Cell/Droppable/index.tsx
+++ b/packages/editor/src/core/components/Cell/Droppable/index.tsx
@@ -93,7 +93,7 @@ const Droppable: React.FC<{ nodeId: string; isLeaf?: boolean }> = (props) => {
   const hoverPosition = useNodeHoverPosition(props.nodeId);
   const options = useOptions();
   const hasPlugin = useCellHasPlugin(props.nodeId);
-  const [, cellSpacingY] = useCellSpacing();
+  const { y: cellSpacingY } = useCellSpacing();
   const needVerticalMargin = !props.isLeaf && !hasPlugin;
 
   if (!(isLayoutMode || isInsertMode) && !options.allowMoveInEditMode) {

--- a/packages/editor/src/core/components/Cell/Inner/index.tsx
+++ b/packages/editor/src/core/components/Cell/Inner/index.tsx
@@ -9,11 +9,11 @@ import {
   useNodeChildrenIds,
   usePluginOfCell,
   useSetEditMode,
+  useCellSpacing,
 } from '../../hooks';
 import Row from '../../Row';
 import Draggable from '../Draggable';
 import Droppable from '../Droppable';
-import InsertNew from '../InsertNew';
 import PluginComponent from '../PluginComponent';
 
 const Inner: React.FC<{ nodeId: string }> = ({ nodeId }) => {
@@ -25,6 +25,7 @@ const Inner: React.FC<{ nodeId: string }> = ({ nodeId }) => {
   const focus = useFocusCell(nodeId);
   const focused = useIsFocused(nodeId);
   const childrenIds = useNodeChildrenIds(nodeId);
+  const cellSpacing = useCellSpacing();
   const ref = React.useRef<HTMLDivElement>();
 
   const hasChildren = childrenIds.length > 0;
@@ -81,9 +82,12 @@ const Inner: React.FC<{ nodeId: string }> = ({ nodeId }) => {
           }
           ref={ref}
         >
-          <PluginComponent nodeId={nodeId} hasChildren={hasChildren}>
+          <PluginComponent
+            nodeId={nodeId}
+            hasChildren={hasChildren}
+            insertAllowed={insertAllowed}
+          >
             {children}
-            {insertAllowed ? <InsertNew parentCellId={nodeId} /> : null}
           </PluginComponent>
         </div>
       </Draggable>

--- a/packages/editor/src/core/components/Cell/Inner/index.tsx
+++ b/packages/editor/src/core/components/Cell/Inner/index.tsx
@@ -1,4 +1,8 @@
 import React from 'react';
+import {
+  getPluginCellSpacing,
+  normalizeCellSpacing,
+} from '../../../utils/getCellSpacing';
 import { getCellStyle } from '../../../utils/getCellStyle';
 import {
   useCellHasPlugin,
@@ -10,6 +14,8 @@ import {
   usePluginOfCell,
   useSetEditMode,
   useCellSpacing,
+  useCellData,
+  useCellSpacingProvider,
 } from '../../hooks';
 import Row from '../../Row';
 import Draggable from '../Draggable';
@@ -30,6 +36,18 @@ const Inner: React.FC<{ nodeId: string }> = ({ nodeId }) => {
   const ref = React.useRef<HTMLDivElement>();
 
   const hasChildren = childrenIds.length > 0;
+
+  const data = useCellData(nodeId);
+  const pluginCellSpacing = getPluginCellSpacing(plugin, data);
+  // eslint-disable-next-line prefer-const
+  let [pluginCellSpacingX, pluginCellSpacingY] = normalizeCellSpacing(
+    pluginCellSpacing
+  );
+  let Provider = useCellSpacingProvider(pluginCellSpacingX, pluginCellSpacingY);
+  if (typeof pluginCellSpacing === 'undefined' || pluginCellSpacing == null) {
+    Provider = (({ children }) => children) as React.FC<unknown>;
+    pluginCellSpacingY = cellSpacingY;
+  }
 
   const onClick = React.useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
@@ -85,9 +103,11 @@ const Inner: React.FC<{ nodeId: string }> = ({ nodeId }) => {
         >
           <PluginComponent nodeId={nodeId} hasChildren={hasChildren}>
             {hasChildren ? (
-              <div style={{ margin: `${-cellSpacingY / 2}px 0` }}>
-                {children}
-              </div>
+              <Provider>
+                <div style={{ margin: `${-pluginCellSpacingY / 2}px 0` }}>
+                  {children}
+                </div>
+              </Provider>
             ) : (
               children
             )}

--- a/packages/editor/src/core/components/Cell/Inner/index.tsx
+++ b/packages/editor/src/core/components/Cell/Inner/index.tsx
@@ -32,21 +32,16 @@ const Inner: React.FC<{ nodeId: string }> = ({ nodeId }) => {
   const focus = useFocusCell(nodeId);
   const focused = useIsFocused(nodeId);
   const childrenIds = useNodeChildrenIds(nodeId);
-  const [, cellSpacingY] = useCellSpacing();
+  let { y: cellSpacingY } = useCellSpacing();
   const ref = React.useRef<HTMLDivElement>();
 
   const hasChildren = childrenIds.length > 0;
 
   const data = useCellData(nodeId);
   const pluginCellSpacing = getPluginCellSpacing(plugin, data);
-  // eslint-disable-next-line prefer-const
-  let [pluginCellSpacingX, pluginCellSpacingY] = normalizeCellSpacing(
-    pluginCellSpacing
-  );
-  let Provider = useCellSpacingProvider(pluginCellSpacingX, pluginCellSpacingY);
-  if (typeof pluginCellSpacing === 'undefined' || pluginCellSpacing == null) {
-    Provider = (({ children }) => children) as React.FC<unknown>;
-    pluginCellSpacingY = cellSpacingY;
+  const [Provider, providerValue] = useCellSpacingProvider(pluginCellSpacing);
+  if (typeof pluginCellSpacing !== 'undefined' && pluginCellSpacing != null) {
+    cellSpacingY = normalizeCellSpacing(pluginCellSpacing).y;
   }
 
   const onClick = React.useCallback(
@@ -103,8 +98,8 @@ const Inner: React.FC<{ nodeId: string }> = ({ nodeId }) => {
         >
           <PluginComponent nodeId={nodeId} hasChildren={hasChildren}>
             {hasChildren ? (
-              <Provider>
-                <div style={{ margin: `${-pluginCellSpacingY / 2}px 0` }}>
+              <Provider value={providerValue}>
+                <div style={{ margin: `${-cellSpacingY / 2}px 0` }}>
                   {children}
                 </div>
               </Provider>

--- a/packages/editor/src/core/components/Cell/Inner/index.tsx
+++ b/packages/editor/src/core/components/Cell/Inner/index.tsx
@@ -14,6 +14,7 @@ import {
 import Row from '../../Row';
 import Draggable from '../Draggable';
 import Droppable from '../Droppable';
+import InsertNew from '../InsertNew';
 import PluginComponent from '../PluginComponent';
 
 const Inner: React.FC<{ nodeId: string }> = ({ nodeId }) => {
@@ -25,7 +26,7 @@ const Inner: React.FC<{ nodeId: string }> = ({ nodeId }) => {
   const focus = useFocusCell(nodeId);
   const focused = useIsFocused(nodeId);
   const childrenIds = useNodeChildrenIds(nodeId);
-  const cellSpacing = useCellSpacing();
+  const [, cellSpacingY] = useCellSpacing();
   const ref = React.useRef<HTMLDivElement>();
 
   const hasChildren = childrenIds.length > 0;
@@ -82,12 +83,15 @@ const Inner: React.FC<{ nodeId: string }> = ({ nodeId }) => {
           }
           ref={ref}
         >
-          <PluginComponent
-            nodeId={nodeId}
-            hasChildren={hasChildren}
-            insertAllowed={insertAllowed}
-          >
-            {children}
+          <PluginComponent nodeId={nodeId} hasChildren={hasChildren}>
+            {hasChildren ? (
+              <div style={{ margin: `${-cellSpacingY / 2}px 0` }}>
+                {children}
+              </div>
+            ) : (
+              children
+            )}
+            {insertAllowed ? <InsertNew parentCellId={nodeId} /> : null}
           </PluginComponent>
         </div>
       </Draggable>

--- a/packages/editor/src/core/components/Cell/NoopProvider.tsx
+++ b/packages/editor/src/core/components/Cell/NoopProvider.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const NoopProvider: React.FC<{ value?: unknown }> = ({ children }) => (
+  <>{children}</>
+);
+
+export default NoopProvider;

--- a/packages/editor/src/core/components/Cell/PluginComponent/index.tsx
+++ b/packages/editor/src/core/components/Cell/PluginComponent/index.tsx
@@ -11,19 +11,22 @@ import {
   useRemoveCell,
   useOptions,
   useCellProps,
+  useCellSpacing,
 } from '../../hooks';
 import PluginMissing from '../PluginMissing';
+import InsertNew from '../InsertNew';
 
 const DefaultProvider: React.FC = ({ children }) => <>{children}</>;
-const PluginComponent: React.FC<{ nodeId: string; hasChildren: boolean }> = ({
-  nodeId,
-  children,
-  hasChildren,
-}) => {
+const PluginComponent: React.FC<{
+  nodeId: string;
+  hasChildren: boolean;
+  insertAllowed: boolean;
+}> = ({ nodeId, children, hasChildren, insertAllowed }) => {
   const lang = useLang();
   const CustomPluginMissing = useOptions()?.components?.CellPluginMissing;
   const isPreviewMode = useIsPreviewMode();
   const isEditMode = useIsEditMode();
+  const cellSpacing = useCellSpacing();
 
   const [data, onChange] = useDebouncedCellData(nodeId);
   const pluginId = useCellProps(nodeId, (c) => c.plugin?.id);
@@ -73,7 +76,16 @@ const PluginComponent: React.FC<{ nodeId: string; hasChildren: boolean }> = ({
           }}
         >
           {Renderer ? (
-            <Renderer {...componentProps}>{children}</Renderer>
+            <Renderer {...componentProps}>
+              {hasChildren ? (
+                <div style={{ marginBottom: `${-cellSpacing}px` }}>
+                  {children}
+                </div>
+              ) : (
+                children
+              )}
+              {insertAllowed ? <InsertNew parentCellId={nodeId} /> : null}
+            </Renderer>
           ) : (
             <Missing {...componentProps} pluginId={pluginId} />
           )}

--- a/packages/editor/src/core/components/Cell/PluginComponent/index.tsx
+++ b/packages/editor/src/core/components/Cell/PluginComponent/index.tsx
@@ -65,6 +65,8 @@ const PluginComponent: React.FC<{ nodeId: string; hasChildren: boolean }> = ({
       <>
         <div
           style={{
+            display: 'flex', // need to cancel margin collapsing (cell spacing support)
+            flexDirection: 'column',
             height: '100%',
             pointerEvents:
               !isPreviewMode && !plugin?.allowClickInside && !hasChildren

--- a/packages/editor/src/core/components/Cell/PluginComponent/index.tsx
+++ b/packages/editor/src/core/components/Cell/PluginComponent/index.tsx
@@ -13,8 +13,8 @@ import {
   useCellProps,
 } from '../../hooks';
 import PluginMissing from '../PluginMissing';
+import NoopProvider from '../NoopProvider';
 
-const DefaultProvider: React.FC = ({ children }) => <>{children}</>;
 const PluginComponent: React.FC<{ nodeId: string; hasChildren: boolean }> = ({
   nodeId,
   children,
@@ -32,7 +32,7 @@ const PluginComponent: React.FC<{ nodeId: string; hasChildren: boolean }> = ({
 
   const Renderer = plugin?.Renderer;
   const Missing = CustomPluginMissing ?? PluginMissing;
-  const Provider = plugin?.Provider ?? DefaultProvider;
+  const Provider = plugin?.Provider ?? NoopProvider;
   const remove = useRemoveCell(nodeId);
 
   const Toolbar = useOptions().components?.BottomToolbar ?? BottomToolbar;

--- a/packages/editor/src/core/components/Cell/PluginComponent/index.tsx
+++ b/packages/editor/src/core/components/Cell/PluginComponent/index.tsx
@@ -11,22 +11,19 @@ import {
   useRemoveCell,
   useOptions,
   useCellProps,
-  useCellSpacing,
 } from '../../hooks';
 import PluginMissing from '../PluginMissing';
-import InsertNew from '../InsertNew';
 
 const DefaultProvider: React.FC = ({ children }) => <>{children}</>;
-const PluginComponent: React.FC<{
-  nodeId: string;
-  hasChildren: boolean;
-  insertAllowed: boolean;
-}> = ({ nodeId, children, hasChildren, insertAllowed }) => {
+const PluginComponent: React.FC<{ nodeId: string; hasChildren: boolean }> = ({
+  nodeId,
+  children,
+  hasChildren,
+}) => {
   const lang = useLang();
   const CustomPluginMissing = useOptions()?.components?.CellPluginMissing;
   const isPreviewMode = useIsPreviewMode();
   const isEditMode = useIsEditMode();
-  const cellSpacing = useCellSpacing();
 
   const [data, onChange] = useDebouncedCellData(nodeId);
   const pluginId = useCellProps(nodeId, (c) => c.plugin?.id);
@@ -76,16 +73,7 @@ const PluginComponent: React.FC<{
           }}
         >
           {Renderer ? (
-            <Renderer {...componentProps}>
-              {hasChildren ? (
-                <div style={{ marginBottom: `${-cellSpacing}px` }}>
-                  {children}
-                </div>
-              ) : (
-                children
-              )}
-              {insertAllowed ? <InsertNew parentCellId={nodeId} /> : null}
-            </Renderer>
+            <Renderer {...componentProps}>{children}</Renderer>
           ) : (
             <Missing {...componentProps} pluginId={pluginId} />
           )}

--- a/packages/editor/src/core/components/Cell/index.tsx
+++ b/packages/editor/src/core/components/Cell/index.tsx
@@ -92,7 +92,8 @@ const Cell: React.FC<Props> = ({ nodeId, measureRef }) => {
   const isLayoutMode = useIsLayoutMode();
   const hasChildren = useNodeHasChildren(nodeId);
   const hasPlugin = useCellHasPlugin(nodeId);
-  const cellSpacing = useCellSpacing();
+  const [cellSpacingX, cellSpacingY] = useCellSpacing();
+  const needVerticalPadding = !hasChildren || hasPlugin;
 
   const isDraftInLang = isDraftI18n?.[lang] ?? isDraft;
   const ref = React.useRef<HTMLDivElement>();
@@ -110,9 +111,9 @@ const Cell: React.FC<Props> = ({ nodeId, measureRef }) => {
   return (
     <div
       style={{
-        padding: `0 ${cellSpacing / 2}px`,
-        paddingBottom:
-          (!hasChildren || hasPlugin) && !inline ? `${cellSpacing}px` : null,
+        padding: `${needVerticalPadding ? cellSpacingY / 2 : 0}px ${
+          cellSpacingX / 2
+        }px`,
       }}
       className={classNames(
         gridClass({

--- a/packages/editor/src/core/components/Cell/index.tsx
+++ b/packages/editor/src/core/components/Cell/index.tsx
@@ -11,6 +11,7 @@ import {
   useLang,
   useNodeHasChildren,
   useScrollToViewEffect,
+  useCellSpacing,
 } from '../hooks';
 import ErrorCell from './ErrorCell';
 import Inner from './Inner';
@@ -91,6 +92,7 @@ const Cell: React.FC<Props> = ({ nodeId, measureRef }) => {
   const isLayoutMode = useIsLayoutMode();
   const hasChildren = useNodeHasChildren(nodeId);
   const hasPlugin = useCellHasPlugin(nodeId);
+  const cellSpacing = useCellSpacing();
 
   const isDraftInLang = isDraftI18n?.[lang] ?? isDraft;
   const ref = React.useRef<HTMLDivElement>();
@@ -107,10 +109,12 @@ const Cell: React.FC<Props> = ({ nodeId, measureRef }) => {
 
   return (
     <div
-      ref={ref}
+      style={{
+        padding: `0 ${cellSpacing / 2}px`,
+        paddingBottom:
+          (!hasChildren || hasPlugin) && !inline ? `${cellSpacing}px` : null,
+      }}
       className={classNames(
-        'react-page-cell',
-
         gridClass({
           isEditMode,
           isPreviewMode,
@@ -118,28 +122,38 @@ const Cell: React.FC<Props> = ({ nodeId, measureRef }) => {
         }),
         {
           'react-page-cell-has-inline-neighbour': hasInlineNeighbour,
+          [`react-page-cell-inline-${inline || ''}`]: inline,
+        }
+      )}
+    >
+      <div
+        ref={ref}
+        className={classNames('react-page-cell', {
           'react-page-cell-has-plugin': hasPlugin,
           'react-page-cell-leaf': !hasChildren,
-          [`react-page-cell-inline-${inline || ''}`]: inline,
           'react-page-cell-focused': focused,
           'react-page-cell-is-draft': isDraftInLang,
           'react-page-cell-bring-to-front':
             !isResizeMode && !isLayoutMode && inline, // inline must not be active for resize/layout
-        }
-      )}
-      onClick={stopClick(isEditMode)}
-    >
-      <Handle nodeId={nodeId} />
-      <div
-        ref={measureRef}
+        })}
+        onClick={stopClick(isEditMode)}
         style={{
           height: '100%',
           boxSizing: 'border-box',
         }}
       >
-        <CellErrorGate nodeId={nodeId}>
-          <Inner nodeId={nodeId} />
-        </CellErrorGate>
+        <Handle nodeId={nodeId} />
+        <div
+          ref={measureRef}
+          style={{
+            height: '100%',
+            boxSizing: 'border-box',
+          }}
+        >
+          <CellErrorGate nodeId={nodeId}>
+            <Inner nodeId={nodeId} />
+          </CellErrorGate>
+        </div>
       </div>
     </div>
   );

--- a/packages/editor/src/core/components/Cell/index.tsx
+++ b/packages/editor/src/core/components/Cell/index.tsx
@@ -92,7 +92,7 @@ const Cell: React.FC<Props> = ({ nodeId, measureRef }) => {
   const isLayoutMode = useIsLayoutMode();
   const hasChildren = useNodeHasChildren(nodeId);
   const hasPlugin = useCellHasPlugin(nodeId);
-  const [cellSpacingX, cellSpacingY] = useCellSpacing();
+  const { x: cellSpacingX, y: cellSpacingY } = useCellSpacing();
   const needVerticalPadding = !hasChildren || hasPlugin;
 
   const isDraftInLang = isDraftI18n?.[lang] ?? isDraft;

--- a/packages/editor/src/core/components/Editable/Inner/index.tsx
+++ b/packages/editor/src/core/components/Editable/Inner/index.tsx
@@ -74,7 +74,7 @@ const Inner: React.FC = () => {
     }
   }, [firstElementInViewPortref.current]);
   const mode = useDisplayMode();
-  const cellSpacing = useCellSpacing();
+  const [, cellSpacingY] = useCellSpacing();
   const insertAllowed = options.childConstraints?.maxChildren
     ? options.childConstraints?.maxChildren > rowIds.length
     : true;
@@ -85,16 +85,14 @@ const Inner: React.FC = () => {
       style={{ minHeight: 480 }}
       className={'react-page-editable react-page-editable-mode-' + mode}
     >
-      <div
-        style={{
-          marginBottom: mode !== 'preview' ? null : `${-cellSpacing}px`,
-        }}
-      >
-        {rowIds.length > 0
-          ? rowIds.map((id) => <Row nodeId={id} key={id} />)
-          : null}
-        {insertAllowed ? <InsertNew /> : null}
-      </div>
+      {rowIds.length > 0 ? (
+        <div style={{ margin: `${-cellSpacingY / 2}px 0` }}>
+          {rowIds.map((id) => (
+            <Row nodeId={id} key={id} />
+          ))}
+        </div>
+      ) : null}
+      {insertAllowed ? <InsertNew /> : null}
     </div>
   );
 };

--- a/packages/editor/src/core/components/Editable/Inner/index.tsx
+++ b/packages/editor/src/core/components/Editable/Inner/index.tsx
@@ -74,7 +74,7 @@ const Inner: React.FC = () => {
     }
   }, [firstElementInViewPortref.current]);
   const mode = useDisplayMode();
-  const [, cellSpacingY] = useCellSpacing();
+  const { y: cellSpacingY } = useCellSpacing();
   const insertAllowed = options.childConstraints?.maxChildren
     ? options.childConstraints?.maxChildren > rowIds.length
     : true;

--- a/packages/editor/src/core/components/Editable/Inner/index.tsx
+++ b/packages/editor/src/core/components/Editable/Inner/index.tsx
@@ -8,9 +8,9 @@ import InsertNew from '../../Cell/InsertNew';
 import Row from '../../Row';
 import {
   useDisplayMode,
-  useIsPreviewMode,
   useOptions,
   useValueNode,
+  useCellSpacing,
 } from '../../hooks';
 
 function isElementInViewport(el: HTMLDivElement) {
@@ -74,6 +74,7 @@ const Inner: React.FC = () => {
     }
   }, [firstElementInViewPortref.current]);
   const mode = useDisplayMode();
+  const cellSpacing = useCellSpacing();
   const insertAllowed = options.childConstraints?.maxChildren
     ? options.childConstraints?.maxChildren > rowIds.length
     : true;
@@ -84,10 +85,16 @@ const Inner: React.FC = () => {
       style={{ minHeight: 480 }}
       className={'react-page-editable react-page-editable-mode-' + mode}
     >
-      {rowIds.length > 0
-        ? rowIds.map((id) => <Row nodeId={id} key={id} />)
-        : null}
-      {insertAllowed ? <InsertNew /> : null}
+      <div
+        style={{
+          marginBottom: mode !== 'preview' ? null : `${-cellSpacing}px`,
+        }}
+      >
+        {rowIds.length > 0
+          ? rowIds.map((id) => <Row nodeId={id} key={id} />)
+          : null}
+        {insertAllowed ? <InsertNew /> : null}
+      </div>
     </div>
   );
 };

--- a/packages/editor/src/core/components/Row/ResizableRowCell.tsx
+++ b/packages/editor/src/core/components/Row/ResizableRowCell.tsx
@@ -8,6 +8,7 @@ import {
   useIsResizeMode,
   useOptions,
   useResizeCell,
+  useCellSpacing,
 } from '../hooks';
 
 type Props = {
@@ -35,6 +36,7 @@ const ResizableRowCell: React.FC<Props> = ({
   const isPreviewMode = useIsPreviewMode();
   const resize = useResizeCell(nodeId);
   const [ref, { height: cellHeight }] = useMeasure();
+  const cellSpacing = useCellSpacing();
 
   const showResizeHandle =
     !isPreviewMode &&
@@ -76,6 +78,7 @@ const ResizableRowCell: React.FC<Props> = ({
             style={{
               // fix floating style
               height: rowHasInlineChildrenPosition ? cellHeight : 'auto',
+              marginBottom: `${cellSpacing}px`,
             }}
           ></div>
         </Draggable>

--- a/packages/editor/src/core/components/Row/ResizableRowCell.tsx
+++ b/packages/editor/src/core/components/Row/ResizableRowCell.tsx
@@ -36,7 +36,7 @@ const ResizableRowCell: React.FC<Props> = ({
   const isPreviewMode = useIsPreviewMode();
   const resize = useResizeCell(nodeId);
   const [ref, { height: cellHeight }] = useMeasure();
-  const [, cellSpacingY] = useCellSpacing();
+  const { y: cellSpacingY } = useCellSpacing();
 
   const showResizeHandle =
     !isPreviewMode &&

--- a/packages/editor/src/core/components/Row/ResizableRowCell.tsx
+++ b/packages/editor/src/core/components/Row/ResizableRowCell.tsx
@@ -29,14 +29,14 @@ const ResizableRowCell: React.FC<Props> = ({
   size,
   maxSize,
 }) => {
-  const stepWidth = Math.round(rowWidth / 12);
+  const stepWidth = rowWidth / 12; // we're going to keep it a real number to preserve some precision
   const { allowResizeInEditMode } = useOptions();
   const isResizeMode = useIsResizeMode();
   const isEditMode = useIsEditMode();
   const isPreviewMode = useIsPreviewMode();
   const resize = useResizeCell(nodeId);
   const [ref, { height: cellHeight }] = useMeasure();
-  const cellSpacing = useCellSpacing();
+  const [, cellSpacingY] = useCellSpacing();
 
   const showResizeHandle =
     !isPreviewMode &&
@@ -52,14 +52,14 @@ const ResizableRowCell: React.FC<Props> = ({
           bounds={{
             top: 0,
             bottom: 0,
-            left: stepWidth,
-            right: rowWidth - stepWidth,
+            left: Math.round(stepWidth),
+            right: Math.round(rowWidth - stepWidth),
           }}
           position={{
             x:
               rowHasInlineChildrenPosition === 'right'
-                ? stepWidth * (12 - offset)
-                : stepWidth * offset,
+                ? Math.round(stepWidth * (12 - offset))
+                : Math.round(stepWidth * offset),
             y: 0,
           }}
           axis="x"
@@ -71,14 +71,14 @@ const ResizableRowCell: React.FC<Props> = ({
                 : size + diff;
             if (newSize > 0 && newSize <= maxSize) resize(newSize);
           }}
-          grid={[stepWidth, 0]}
+          grid={[Math.round(stepWidth), 0]}
         >
           <div
             className="resize-handle"
             style={{
               // fix floating style
               height: rowHasInlineChildrenPosition ? cellHeight : 'auto',
-              marginBottom: `${cellSpacing}px`,
+              margin: `${cellSpacingY / 2}px 0`,
             }}
           ></div>
         </Draggable>

--- a/packages/editor/src/core/components/Row/index.css
+++ b/packages/editor/src/core/components/Row/index.css
@@ -64,7 +64,7 @@
   width: 4px;
   top: 0;
   bottom: 0;
-  left: -4px;
+  left: -2px;
   cursor: e-resize;
   background-color: var(--lightBlack);
   mix-blend-mode: difference;

--- a/packages/editor/src/core/components/Row/index.tsx
+++ b/packages/editor/src/core/components/Row/index.tsx
@@ -49,28 +49,39 @@ const Row: React.FC<{ nodeId: string }> = ({ nodeId }) => {
     (node) => isRow(node) && node.cells.length === 2 && node.cells[0]?.inline
   );
 
-  const cellSpacing = useCellSpacing();
+  const [cellSpacingX, cellSpacingY] = useCellSpacing();
 
   return (
     <Droppable nodeId={nodeId}>
       <div
         ref={ref}
         className={classNames('react-page-row', {
-          'react-page-row-is-hovering-this': Boolean(hoverPosition),
-          [`react-page-row-is-hovering-${hoverPosition || ''}`]: Boolean(
-            hoverPosition
-          ),
           'react-page-row-has-floating-children': Boolean(
             rowHasInlineChildrenPosition
           ),
         })}
         style={{
           position: 'relative',
-          borderColor: 'red',
-          margin: `0 ${-cellSpacing / 2}px`,
+          margin: `0 ${-cellSpacingX / 2}px`,
         }}
         onClick={blurAllCells}
       >
+        <div
+          style={{
+            position: 'absolute',
+            pointerEvents: 'none',
+            top: `${cellSpacingY / 2}px`,
+            left: `${cellSpacingX / 2}px`,
+            bottom: `${cellSpacingY / 2}px`,
+            right: `${cellSpacingX / 2}px`,
+          }}
+          className={classNames({
+            'react-page-row-is-hovering-this': Boolean(hoverPosition),
+            [`react-page-row-is-hovering-${hoverPosition || ''}`]: Boolean(
+              hoverPosition
+            ),
+          })}
+        />
         {childrenWithOffsets.map(({ offset, id, size, maxSize }, index) => (
           <ResizableRowCell
             key={id}

--- a/packages/editor/src/core/components/Row/index.tsx
+++ b/packages/editor/src/core/components/Row/index.tsx
@@ -2,7 +2,12 @@ import classNames from 'classnames';
 import React from 'react';
 import { useMeasure } from 'react-use';
 import { isRow, Node, Row } from '../../types/node';
-import { useBlurAllCells, useNodeHoverPosition, useNodeProps } from '../hooks';
+import {
+  useBlurAllCells,
+  useCellSpacing,
+  useNodeHoverPosition,
+  useNodeProps,
+} from '../hooks';
 import Droppable from './Droppable';
 import ResizableRowCell from './ResizableRowCell';
 
@@ -44,6 +49,8 @@ const Row: React.FC<{ nodeId: string }> = ({ nodeId }) => {
     (node) => isRow(node) && node.cells.length === 2 && node.cells[0]?.inline
   );
 
+  const cellSpacing = useCellSpacing();
+
   return (
     <Droppable nodeId={nodeId}>
       <div
@@ -57,7 +64,11 @@ const Row: React.FC<{ nodeId: string }> = ({ nodeId }) => {
             rowHasInlineChildrenPosition
           ),
         })}
-        style={{ position: 'relative', borderColor: 'red' }}
+        style={{
+          position: 'relative',
+          borderColor: 'red',
+          margin: `0 ${-cellSpacing / 2}px`,
+        }}
         onClick={blurAllCells}
       >
         {childrenWithOffsets.map(({ offset, id, size, maxSize }, index) => (

--- a/packages/editor/src/core/components/Row/index.tsx
+++ b/packages/editor/src/core/components/Row/index.tsx
@@ -49,7 +49,7 @@ const Row: React.FC<{ nodeId: string }> = ({ nodeId }) => {
     (node) => isRow(node) && node.cells.length === 2 && node.cells[0]?.inline
   );
 
-  const [cellSpacingX, cellSpacingY] = useCellSpacing();
+  const { x: cellSpacingX, y: cellSpacingY } = useCellSpacing();
 
   return (
     <Droppable nodeId={nodeId}>

--- a/packages/editor/src/core/components/hooks/options.ts
+++ b/packages/editor/src/core/components/hooks/options.ts
@@ -60,3 +60,10 @@ export const useConfiguredCellPlugin = (pluginId: string) => {
 export const useLang = () => {
   return useSelector(getLang);
 };
+
+/**
+ * @returns cell spacing for the current cell sub-tree
+ */
+export const useCellSpacing = () => {
+  return +useOptions().cellSpacing || 0;
+};

--- a/packages/editor/src/core/components/hooks/options.ts
+++ b/packages/editor/src/core/components/hooks/options.ts
@@ -64,6 +64,11 @@ export const useLang = () => {
 /**
  * @returns cell spacing for the current cell sub-tree
  */
-export const useCellSpacing = () => {
-  return +useOptions().cellSpacing || 0;
+export const useCellSpacing: () => [number, number] = () => {
+  const spacing = useOptions().cellSpacing;
+  if (!Array.isArray(spacing)) {
+    return [+spacing || 0, +spacing || 0];
+  } else {
+    return [+spacing[0] || 0, +spacing[1] || 0];
+  }
 };

--- a/packages/editor/src/core/components/hooks/options.ts
+++ b/packages/editor/src/core/components/hooks/options.ts
@@ -80,9 +80,9 @@ export const useCellSpacingProvider = (
     () => ({ ...options, cellSpacing: normalizeCellSpacing(cellSpacing) }),
     [options, JSON.stringify(cellSpacing)]
   );
-  if (cellSpacing) {
-    return [OptionsContext.Provider, value];
-  } else {
+  if (typeof cellSpacing === 'undefined' || cellSpacing == null) {
     return [NoopProvider, undefined];
+  } else {
+    return [OptionsContext.Provider, value];
   }
 };

--- a/packages/editor/src/core/components/hooks/options.tsx
+++ b/packages/editor/src/core/components/hooks/options.tsx
@@ -1,9 +1,9 @@
-import { createContext, useContext } from 'react';
+import React, { createContext, useContext } from 'react';
 import EditorStore, { EditorContext } from '../../EditorStore';
 import { useSelector } from '../../reduxConnect';
 import { getLang } from '../../selector/setting';
-
 import { Options } from '../../types/node';
+import { normalizeCellSpacing } from '../../utils/getCellSpacing';
 
 /**
  * @returns the store object of the current editor. Contains the redux store.
@@ -65,10 +65,22 @@ export const useLang = () => {
  * @returns cell spacing for the current cell sub-tree
  */
 export const useCellSpacing: () => [number, number] = () => {
-  const spacing = useOptions().cellSpacing;
-  if (!Array.isArray(spacing)) {
-    return [+spacing || 0, +spacing || 0];
-  } else {
-    return [+spacing[0] || 0, +spacing[1] || 0];
-  }
+  return normalizeCellSpacing(useOptions().cellSpacing);
+};
+
+/**
+ * @returns a Provider component that can be used to override cell spacing for a subtree of cells
+ */
+export const useCellSpacingProvider = (
+  cellSpacingX: number,
+  cellSpacingY: number
+) => {
+  const options = useOptions();
+  return (({ children }) => (
+    <OptionsContext.Provider
+      value={{ ...options, cellSpacing: [cellSpacingX, cellSpacingY] }}
+    >
+      {children}
+    </OptionsContext.Provider>
+  )) as React.FC<unknown>;
 };

--- a/packages/editor/src/core/types/node.ts
+++ b/packages/editor/src/core/types/node.ts
@@ -142,4 +142,9 @@ export type Options = {
    * Internal component overrides.
    */
   components?: Components;
+
+  /**
+   * Sets the size of the cell grid gutters in pixels.
+   */
+  cellSpacing?: number;
 } & SimplifiedModesProps;

--- a/packages/editor/src/core/types/node.ts
+++ b/packages/editor/src/core/types/node.ts
@@ -146,5 +146,5 @@ export type Options = {
   /**
    * Sets the size of the cell grid gutters in pixels.
    */
-  cellSpacing?: number;
+  cellSpacing?: number | [number, number];
 } & SimplifiedModesProps;

--- a/packages/editor/src/core/types/node.ts
+++ b/packages/editor/src/core/types/node.ts
@@ -104,6 +104,11 @@ export type SimplifiedModesProps = {
   allowMoveInEditMode?: boolean;
 };
 
+export type CellSpacing = {
+  x: number;
+  y: number;
+};
+
 // DND
 
 export type CellDrag = {
@@ -146,5 +151,5 @@ export type Options = {
   /**
    * Sets the size of the cell grid gutters in pixels.
    */
-  cellSpacing?: number | [number, number];
+  cellSpacing?: number | CellSpacing;
 } & SimplifiedModesProps;

--- a/packages/editor/src/core/types/plugins.ts
+++ b/packages/editor/src/core/types/plugins.ts
@@ -1,9 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
-import { AnyAction } from 'redux';
-
 import type { Migration } from '../migrations/Migration';
-import { Cell, PartialCell, PartialRow } from './node';
+import { Cell, CellSpacing, PartialCell, PartialRow } from './node';
 import { JsonSchema } from './jsonSchema';
 import { ChildConstraints } from './constraints';
 
@@ -180,10 +178,7 @@ export type CellPlugin<DataT = unknown, DataSerializedT = DataT> = {
   /**
    * cell spacing setting for the internal layout (nested cells) if any
    */
-  cellSpacing?:
-    | number
-    | [number, number]
-    | ((data: DataT) => number | [number, number]);
+  cellSpacing?: number | CellSpacing | ((data: DataT) => number | CellSpacing);
 
   /**
    * defines constraint about the children that can be added to this Cell.

--- a/packages/editor/src/core/types/plugins.ts
+++ b/packages/editor/src/core/types/plugins.ts
@@ -178,6 +178,14 @@ export type CellPlugin<DataT = unknown, DataSerializedT = DataT> = {
   cellStyle?: React.CSSProperties | (() => React.CSSProperties);
 
   /**
+   * cell spacing setting for the internal layout (nested cells) if any
+   */
+  cellSpacing?:
+    | number
+    | [number, number]
+    | ((data: DataT) => number | [number, number]);
+
+  /**
    * defines constraint about the children that can be added to this Cell.
    * Only useful if you render children in your Component
    *

--- a/packages/editor/src/core/utils/getCellSpacing.ts
+++ b/packages/editor/src/core/utils/getCellSpacing.ts
@@ -1,0 +1,21 @@
+import { CellPlugin } from '../types';
+
+export const getPluginCellSpacing = <DataT>(
+  plugin: CellPlugin<DataT>,
+  data: DataT
+) =>
+  plugin?.cellSpacing
+    ? typeof plugin?.cellSpacing === 'function'
+      ? plugin?.cellSpacing(data)
+      : plugin?.cellSpacing
+    : undefined;
+
+export const normalizeCellSpacing = (
+  cellSpacing: number | [number, number]
+): [number, number] => {
+  if (!Array.isArray(cellSpacing)) {
+    return [+cellSpacing || 0, +cellSpacing || 0];
+  } else {
+    return [+cellSpacing[0] || 0, +cellSpacing[1] || 0];
+  }
+};

--- a/packages/editor/src/core/utils/getCellSpacing.ts
+++ b/packages/editor/src/core/utils/getCellSpacing.ts
@@ -1,9 +1,9 @@
-import { CellPlugin } from '../types';
+import { CellPlugin, CellSpacing } from '../types';
 
 export const getPluginCellSpacing = <DataT>(
   plugin: CellPlugin<DataT>,
   data: DataT
-) =>
+): number | CellSpacing | undefined =>
   plugin?.cellSpacing
     ? typeof plugin?.cellSpacing === 'function'
       ? plugin?.cellSpacing(data)
@@ -11,11 +11,14 @@ export const getPluginCellSpacing = <DataT>(
     : undefined;
 
 export const normalizeCellSpacing = (
-  cellSpacing: number | [number, number]
-): [number, number] => {
-  if (!Array.isArray(cellSpacing)) {
-    return [+cellSpacing || 0, +cellSpacing || 0];
+  cellSpacing?: number | CellSpacing
+): CellSpacing => {
+  if (!cellSpacing || ['number', 'string'].indexOf(typeof cellSpacing) !== -1) {
+    return { x: +cellSpacing || 0, y: +cellSpacing || 0 };
   } else {
-    return [+cellSpacing[0] || 0, +cellSpacing[1] || 0];
+    return {
+      x: +(cellSpacing as CellSpacing).x || 0,
+      y: +(cellSpacing as CellSpacing).y || 0,
+    };
   }
 };

--- a/packages/editor/src/editor/EditableEditor.tsx
+++ b/packages/editor/src/editor/EditableEditor.tsx
@@ -39,6 +39,7 @@ const EditableEditor: React.FC<EditableEditorProps> = ({
   editModeResizeHandle,
   childConstraints,
   components,
+  cellSpacing,
 }) => {
   const theValue = value || createEmptyState();
   return (
@@ -58,6 +59,7 @@ const EditableEditor: React.FC<EditableEditorProps> = ({
       blurGateDefaultMode={defaultDisplayMode}
       childConstraints={childConstraints}
       components={components}
+      cellSpacing={cellSpacing}
     >
       <StickyWrapper>
         {(stickyNess) => (

--- a/packages/editor/src/editor/Editor.tsx
+++ b/packages/editor/src/editor/Editor.tsx
@@ -54,6 +54,7 @@ const Editor: React.FC<EditorProps> = ({
   languages,
   lang = languages?.[0].lang ?? 'default',
   pluginsWillChange,
+  cellSpacing,
   ...rest
 }) => {
   // mount the component always in readonly, to avoid problems with SSR
@@ -63,11 +64,21 @@ const Editor: React.FC<EditorProps> = ({
   }, [readOnly]);
 
   return renderReadOnly ? (
-    <HTMLRenderer value={value} cellPlugins={cellPlugins} lang={lang} />
+    <HTMLRenderer
+      value={value}
+      cellPlugins={cellPlugins}
+      lang={lang}
+      cellSpacing={cellSpacing}
+    />
   ) : (
     <EditableEditor
       fallback={
-        <HTMLRenderer value={value} cellPlugins={cellPlugins} lang={lang} />
+        <HTMLRenderer
+          value={value}
+          cellPlugins={cellPlugins}
+          lang={lang}
+          cellSpacing={cellSpacing}
+        />
       }
       pluginsWillChange={pluginsWillChange}
       cellPlugins={cellPlugins}
@@ -78,6 +89,7 @@ const Editor: React.FC<EditorProps> = ({
       defaultDisplayMode={defaultDisplayMode}
       lang={lang}
       languages={languages}
+      cellSpacing={cellSpacing}
       {...rest}
     />
   );

--- a/packages/editor/src/renderer/HTMLRenderer.tsx
+++ b/packages/editor/src/renderer/HTMLRenderer.tsx
@@ -2,9 +2,14 @@ import classNames from 'classnames';
 import React from 'react';
 import { migrateValue } from '../core/migrations/migrate';
 import { setAllSizesAndOptimize } from '../core/reducer/value/helper/setAllSizesAndOptimize';
+import { optimizeRows } from '../core/reducer/value/helper/optimize';
 import type { Cell, CellPlugin, Row, ValueWithLegacy } from '../core/types';
 import { getCellData } from '../core/utils/getCellData';
 import { getCellStyle } from '../core/utils/getCellStyle';
+import {
+  getPluginCellSpacing,
+  normalizeCellSpacing,
+} from '../core/utils/getCellSpacing';
 
 const gridClass = (size = 12): string =>
   `react-page-cell-sm-${size} react-page-cell-xs-12`;
@@ -13,18 +18,40 @@ const rowHasInlineChildren = ({ cells }) =>
   Boolean(cells.length === 2 && Boolean(cells[0].inline));
 
 const HTMLRow: React.FC<
-  Partial<Row & { lang: string; className?: string; cellPlugins: CellPlugin[] }>
-> = React.memo(({ cells = [], className, lang, cellPlugins }) => (
-  <div
-    className={classNames('react-page-row', className, {
-      'react-page-row-has-floating-children': rowHasInlineChildren({ cells }),
-    })}
+  Partial<
+    Row & {
+      lang: string;
+      className?: string;
+      cellPlugins: CellPlugin[];
+      cellSpacing: [number, number];
+    }
   >
-    {cells.map((c, index) => (
-      <HTMLCell key={c.id} {...c} lang={lang} cellPlugins={cellPlugins} />
-    ))}
-  </div>
-));
+> = React.memo(
+  ({
+    cells = [],
+    className,
+    lang,
+    cellPlugins,
+    cellSpacing: [cellSpacingX, cellSpacingY],
+  }) => (
+    <div
+      className={classNames('react-page-row', className, {
+        'react-page-row-has-floating-children': rowHasInlineChildren({ cells }),
+      })}
+      style={{ margin: `0 ${-cellSpacingX / 2}px` }}
+    >
+      {cells.map((c, index) => (
+        <HTMLCell
+          key={c.id}
+          {...c}
+          lang={lang}
+          cellPlugins={cellPlugins}
+          cellSpacing={[cellSpacingX, cellSpacingY]}
+        />
+      ))}
+    </div>
+  )
+);
 
 // eslint-disable-next-line no-empty-function
 const noop = () => {
@@ -34,15 +61,26 @@ const noop = () => {
 const DefaultProvider: React.FC = ({ children }) => <>{children}</>;
 
 const HTMLCell: React.FC<
-  Cell & { lang: string; cellPlugins: CellPlugin[] }
+  Cell & {
+    lang: string;
+    cellPlugins: CellPlugin[];
+    cellSpacing: [number, number];
+  }
 > = React.memo((props) => {
-  const { lang, cellPlugins, ...cell } = props;
+  const {
+    lang,
+    cellPlugins,
+    cellSpacing: [cellSpacingX, cellSpacingY],
+    ...cell
+  } = props;
   const { size, hasInlineNeighbour, inline, isDraftI18n, isDraft } = cell;
   const hasChildren = cell.rows?.length > 0;
-  const cn = classNames('react-page-cell', gridClass(size), {
+  const cnOuter = classNames(gridClass(size), {
     'react-page-cell-has-inline-neighbour': hasInlineNeighbour,
-    'react-page-cell-leaf': !hasChildren,
     [`react-page-cell-inline-${inline || ''}`]: inline,
+  });
+  const cnInner = classNames('react-page-cell', {
+    'react-page-cell-leaf': !hasChildren,
   });
 
   if (isDraftI18n?.[lang] ?? isDraft) {
@@ -57,6 +95,10 @@ const HTMLCell: React.FC<
     const cellStyle = getCellStyle(plugin);
     const Provider = plugin.Provider ?? DefaultProvider;
     const data = getCellData(cell, lang);
+    const pluginCellSpacing = getPluginCellSpacing(plugin, data);
+    const [pluginCellSpacingX, pluginCellSpacingY] = pluginCellSpacing
+      ? normalizeCellSpacing(pluginCellSpacing)
+      : [cellSpacingX, cellSpacingY];
     const props = {
       readOnly: true,
       lang: lang,
@@ -70,48 +112,70 @@ const HTMLCell: React.FC<
     };
     return (
       <Provider {...props}>
-        <div className={cn}>
-          <div
-            style={cellStyle}
-            className={
-              'react-page-cell-inner' +
-              (cell.rows?.length > 0 ? '' : ' react-page-cell-inner-leaf')
-            }
-          >
-            <Renderer {...props}>
-              {cell.rows?.map((r: Row, index) => (
-                <HTMLRow
-                  key={r.id}
-                  {...r}
-                  cellPlugins={cellPlugins}
-                  lang={lang}
-                  className="react-page-cell-inner"
-                />
-              ))}
-            </Renderer>
+        <div
+          className={cnOuter}
+          style={{ padding: `${cellSpacingY / 2}px ${cellSpacingX / 2}px` }}
+        >
+          <div className={cnInner}>
+            <div
+              style={cellStyle}
+              className={
+                'react-page-cell-inner' +
+                (cell.rows?.length > 0 ? '' : ' react-page-cell-inner-leaf')
+              }
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                }}
+              >
+                <Renderer {...props}>
+                  {cell.rows?.length ? (
+                    <div style={{ margin: `${-pluginCellSpacingY / 2}px 0` }}>
+                      {cell.rows?.map((r: Row) => (
+                        <HTMLRow
+                          key={r.id}
+                          {...r}
+                          cellPlugins={cellPlugins}
+                          cellSpacing={[pluginCellSpacingX, pluginCellSpacingY]}
+                          lang={lang}
+                          className="react-page-cell-inner"
+                        />
+                      ))}
+                    </div>
+                  ) : null}
+                </Renderer>
+              </div>
+            </div>
           </div>
         </div>
       </Provider>
     );
   } else if (cell.rows?.length > 0) {
     return (
-      <div className={cn}>
-        {cell.rows.map((r: Row) => (
-          <HTMLRow
-            key={r.id}
-            {...r}
-            lang={lang}
-            className="react-page-cell-inner"
-            cellPlugins={cellPlugins}
-          />
-        ))}
+      <div className={cnOuter} style={{ padding: `0 ${cellSpacingX / 2}px` }}>
+        <div className={cnInner}>
+          {cell.rows.map((r: Row) => (
+            <HTMLRow
+              key={r.id}
+              {...r}
+              lang={lang}
+              className="react-page-cell-inner"
+              cellPlugins={cellPlugins}
+              cellSpacing={[cellSpacingX, cellSpacingY]}
+            />
+          ))}
+        </div>
       </div>
     );
   }
 
   return (
-    <div className={cn}>
-      <div className="react-page-cell-inner" />
+    <div className={cnOuter}>
+      <div className={cnInner}>
+        <div className="react-page-cell-inner" />
+      </div>
     </div>
   );
 });
@@ -120,27 +184,33 @@ export interface HTMLRendererProps {
   value: ValueWithLegacy;
   cellPlugins?: CellPlugin[];
   lang?: string;
+  cellSpacing?: number | [number, number];
 }
 
 export const HTMLRenderer: React.FC<HTMLRendererProps> = React.memo(
-  ({ value, cellPlugins, lang = 'default' }) => {
+  ({ value, cellPlugins, cellSpacing, lang = 'default' }) => {
     const data = migrateValue(value, { cellPlugins, lang });
+    const [cellSpacingX, cellSpacingY] = normalizeCellSpacing(cellSpacing);
 
     if (!data) {
       return null;
     }
     const { rows } = data;
+    const optRows = optimizeRows(rows);
     return (
-      <>
-        {setAllSizesAndOptimize(rows).map((row) => (
+      <div
+        style={{ margin: optRows?.length ? `${-cellSpacingY / 2}px 0` : null }}
+      >
+        {setAllSizesAndOptimize(optRows).map((row) => (
           <HTMLRow
             key={row.id}
             cellPlugins={cellPlugins}
             lang={lang}
+            cellSpacing={[cellSpacingX, cellSpacingY]}
             {...row}
           />
         ))}
-      </>
+      </div>
     );
   }
 );

--- a/packages/editor/src/renderer/__tests__/index.test.tsx
+++ b/packages/editor/src/renderer/__tests__/index.test.tsx
@@ -53,7 +53,7 @@ describe('HTMLRenderer', () => {
         it('should pass', () => {
           expect(wrapper.html()).toEqual(
             // tslint:disable-next-line:max-line-length
-            '<div class="react-page-cell react-page-cell-sm-12 react-page-cell-xs-12 react-page-cell-leaf"><div class="react-page-cell-inner react-page-cell-inner-leaf"><p>Hello world</p></div></div>'
+            '<div class="react-page-row" style="margin:0 0px"><div class="react-page-cell-sm-12 react-page-cell-xs-12" style="padding:0px 0px"><div class="react-page-cell react-page-cell-leaf"><div class="react-page-cell-inner react-page-cell-inner-leaf"><div style="display:flex;flex-direction:column"><p>Hello world</p></div></div></div></div></div>'
           );
         });
       });

--- a/packages/plugins/layout/background/src/index.css
+++ b/packages/plugins/layout/background/src/index.css
@@ -5,6 +5,8 @@
   color: white;
   padding: 12px;
   position: relative;
+  height: 100%;
+  box-sizing: border-box;
 }
 
 .react-page-plugins-layout-background > .react-page-row {

--- a/packages/plugins/layout/background/src/index.css
+++ b/packages/plugins/layout/background/src/index.css
@@ -5,8 +5,6 @@
   color: white;
   padding: 12px;
   position: relative;
-  height: 100%;
-  box-sizing: border-box;
 }
 
 .react-page-plugins-layout-background > .react-page-row {


### PR DESCRIPTION
## Proposed changes

Add `cellSpacing` prop to the Editor where they can specify the sizes of grid gutters (vertical and horizontal).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Closing issues

#918

## Further comments

See examples/pages/examples/cellSpacing.tsx for the demonstration of the new functionality.

The main layout change is the split of .react-page-cell into two divs. The outer div gets all the flexgrid classes, inline classes (floats) and it's the div that gets all the paddings that constitute the gutters. The inner div retains all the rest of the classes and is the div that gets highlighted when a cell is selected.

Horizontal padding compensation is done by applying a negative margin to the .react-page-row class.

Vertical compensation is only needed for
- nested grids (layout plugins) and is applies to the new div that encloses the plugin's children (excluding the InsertNew component).
- the entire editor -- applied inside Editable/Inner component
