### PR TITLE
Multi controls

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -7,6 +7,7 @@
 - [Rich text editing](/slate.md)
 - [Custom Cell plugins](/custom-cell-plugins.md)
 - [Builtin Cell Plugins](/builtin_plugins.md)
+- [Recipes & Tips](/recipes.md)
 - Integrations
 
   - [React Admin](/integration-react-admin.md)

--- a/docs/custom-cell-plugins.md
+++ b/docs/custom-cell-plugins.md
@@ -90,12 +90,21 @@ in some cases you might require additional information:
 - `readOnly` (boolean): true means the editor just shows the content.
 - `onChange`: (function): You can call `onChange` to update the cell with new data
 
+### `cellStyle`
+
+`cellStyle` can be a style object (`CSSProperties`) or a function that returns a style object. This function receives the `data` of the plugin as argument.
+
+This style will be applied to the outermost div of the cell, not to the Component specified in `Renderer`.
+
+This is useful to customize paddings of a cell or similar.
+
 ### `controls`
 
-one of two types:
+one of three types:
 
 - `{ type: 'autoform' }`,
 - `{ type: 'custom' }`:
+- an Array of `{ title: string, controls: {...} }`:
 
 See the following chapter.
 
@@ -201,6 +210,60 @@ Feel free to open an issue with your usecase as we want to make `type: "autoform
 `controls: { type: 'custom' }` takes these options:
 
 - `Component`: the custom component you want to use for editing. It receives the same props as `Renderer` and an `onChange` property. Call this function to pass new data to the plugin. The current data is passed in as `data`.
+
+## Multiple Controls
+
+You can specify multiple controls each with a title. Plugin with multiple controls will show additional Tabs in the Toolbar
+to switch between the controls:
+
+```tsx
+const customContentPlugin: CellPlugin<{
+  title: string;
+  advancedProperty: string;
+}> = {
+  id: 'my-plugin',
+  controls: [
+    {
+      title: 'Basse config',
+      controls: {
+        type: 'autoform',
+        schema: {
+          properties: {
+            title: {
+              type: 'string',
+            },
+          },
+          required: [],
+        },
+      },
+    },
+    {
+      title: 'Advanced',
+      controls: {
+        type: 'autoform',
+        schema: {
+          type: 'object',
+          required: [],
+          properties: {
+            advancedProperty: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    },
+  ],
+};
+```
+
+[See working example here](//demo/examples/multicontrols)
+
+<details>
+  <summary>Show example (click to expand)</summary>
+
+[customContentPlugin.tsx](examples/plugins/customContentPlugin.tsx ':include :type=code typescript')
+
+</details>
 
 ## Advanced props
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,7 +26,7 @@
     window.$docsify = {
       search: 'auto', // default
       name: 'React-page',
-      repo: 'https://github.com/react-page/react-page',
+      repo: 'https://github.com/react-page/eitor',
       loadSidebar: '_sidebar.md',
       subMaxLevel: 3,
 
@@ -36,7 +36,7 @@
         function (hook, vm) {
           hook.beforeEach((markdown) => {
 
-            const result = markdown.replace(/]\(\/\/demo\//g, `](${"https://react-page.github.io/beta"/*"http://localhost:3000"*/}/examples/`)
+            const result = markdown.replace(/]\(\/\/demo\//g, `](${document.location.origin}/`)
             return result
           })
         }

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -39,7 +39,7 @@ To get off the ground as soon as possible, simply create a component like so:
 
 That's it, congratulations!
 
-[You should see something like this now (click for the demo)](//demo/simple)
+[You should see something like this now (click for the demo)](//demo/examples/simple)
 
 ## Readonly
 
@@ -51,4 +51,4 @@ We won't load any UI related code unless readOnly changes to `false`. In this ca
 
 [simple.tsx](examples/pages/examples/readonly.tsx ':include :type=code typescript')
 
-(see demo here)](//demo/readonly)
+(see demo here)](//demo/examples/readonly)

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,0 +1,57 @@
+# Recipes
+
+## Add additional controls to all cell plugins
+
+Consider you want to add custom styling to all plugins. Because a `CellPlugin` is just an object, its easy to customize it.
+You can use a map function to customize a list of plugings:
+
+```tsx
+import { CellPlugin } from '@react-page/editor';
+
+const rawCellPlugins = [slate(), image, background, myPlugin];
+
+type Styling = {
+  padding?: number;
+};
+
+const myCellPlugins = rawCellPlugins.map<CellPlugin<Styling>>((plugin) => {
+  return {
+    ...plugin,
+    // customize cellStyle
+    // you could also wrap `Renderer` in an additional Component
+    cellStyle: (data) => ({
+      padding: data.padding,
+    }),
+    controls: [
+      {
+        title: 'Main',
+        controls: p.controls,
+      },
+      {
+        title: 'Styling',
+        controls: {
+          type: 'autoform',
+          schema: {
+            properties: {
+              padding: {
+                type: 'number',
+              },
+            },
+          },
+        },
+      },
+    ],
+  };
+});
+```
+
+Full Example:
+
+[See working example here](//demo/examples/decorateplugins)
+
+<details>
+  <summary>Show example (click to expand)</summary>
+
+[decorateplugins.tsx](examples/pages/examples/decorateplugins.tsx ':include :type=code typescript')
+
+</details>

--- a/examples/pages/examples/decorateplugins.tsx
+++ b/examples/pages/examples/decorateplugins.tsx
@@ -1,0 +1,71 @@
+// The editor core
+import { CSSProperties } from '@material-ui/styles';
+import Editor, { CellPlugin, Value } from '@react-page/editor';
+
+import React, { useState } from 'react';
+import PageLayout from '../../components/PageLayout';
+import { cellPlugins } from '../../plugins/cellPlugins';
+import { demo } from '../../sampleContents/demo';
+
+type Styling = {
+  paddingLeft?: number;
+  paddingRight?: number;
+  paddingBottom?: number;
+  paddingTop?: number;
+  border?: CSSProperties['border'];
+};
+const pluginsWithMargin = cellPlugins.map<CellPlugin<Styling>>((p) => ({
+  ...p,
+  cellStyle: (data) => ({
+    paddingLeft: data.paddingLeft,
+    paddingRight: data.paddingRight,
+    paddingTop: data.paddingTop,
+    paddingBottom: data.paddingBottom,
+    border: data.border,
+  }),
+  controls: [
+    {
+      title: 'Main',
+      controls: p.controls,
+    },
+    {
+      title: 'Styling',
+      controls: {
+        type: 'autoform',
+        columnCount: 3,
+        schema: {
+          properties: {
+            paddingLeft: {
+              type: 'number',
+            },
+            paddingRight: {
+              type: 'number',
+            },
+            paddingBottom: {
+              type: 'number',
+            },
+            paddingTop: {
+              type: 'number',
+            },
+            border: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    },
+  ],
+}));
+export default function DecoratedPlugins() {
+  const [value, setValue] = useState<Value>(demo);
+
+  return (
+    <PageLayout>
+      <Editor
+        value={value}
+        onChange={setValue}
+        cellPlugins={pluginsWithMargin}
+      />
+    </PageLayout>
+  );
+}

--- a/examples/pages/examples/multicontrols.tsx
+++ b/examples/pages/examples/multicontrols.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+
+// The editor core
+import Editor, { createValue, Value } from '@react-page/editor';
+
+// import the main css, uncomment this: (this is commented in the example because of https://github.com/vercel/next.js/issues/19717)
+// import '@react-page/editor/lib/index.css';
+
+// The rich text area plugin
+import slate from '@react-page/plugins-slate';
+
+import PageLayout from '../../components/PageLayout';
+import customContentPlugin from '../../plugins/customContentPlugin';
+
+// Stylesheets for the rich text area plugin
+// uncomment this
+//import '@react-page/plugins-slate/lib/index.css';
+
+// Stylesheets for the imagea plugin
+//import '@react-page/plugins-image/lib/index.css';
+
+// Define which plugins we want to use.
+const cellPlugins = [slate(), customContentPlugin];
+
+const INITIAL_VALUE = createValue(
+  {
+    rows: [
+      [
+        {
+          plugin: customContentPlugin,
+        },
+      ],
+    ],
+  },
+  {
+    cellPlugins,
+    lang: 'default',
+  }
+);
+export default function MultiControls() {
+  const [value, setValue] = useState<Value>(INITIAL_VALUE);
+
+  return (
+    <PageLayout>
+      <Editor cellPlugins={cellPlugins} value={value} onChange={setValue} />
+    </PageLayout>
+  );
+}

--- a/examples/plugins/customContentPlugin.tsx
+++ b/examples/plugins/customContentPlugin.tsx
@@ -28,7 +28,7 @@ const customContentPlugin: CellPlugin<{
   ),
   id: 'custom-content-plugin',
   title: 'Custom content plugin',
-  description: 'Some custom content plugin',
+  description: 'Some custom content plugin with multiple controls',
   version: 1,
   controls: [
     {
@@ -39,7 +39,8 @@ const customContentPlugin: CellPlugin<{
           properties: {
             title: {
               type: 'string',
-              default: 'I am a custom plugin, this is my configuration',
+              default:
+                'I am a custom plugin with multiple controls, this is my configuration',
             },
             firstName: { type: 'string' },
             lastName: { type: 'string' },

--- a/examples/plugins/customContentPlugin.tsx
+++ b/examples/plugins/customContentPlugin.tsx
@@ -1,4 +1,4 @@
-import { CellPlugin } from '@react-page/editor';
+import { CellPlugin, ColorPickerField } from '@react-page/editor';
 import React from 'react';
 
 const customContentPlugin: CellPlugin<{
@@ -6,9 +6,20 @@ const customContentPlugin: CellPlugin<{
   firstName: string;
   lastName: string;
   age: number;
+  style: {
+    backgroundColor: string;
+    textColor: string;
+    padding: number;
+  };
 }> = {
   Renderer: ({ data }) => (
-    <div>
+    <div
+      style={{
+        backgroundColor: data.style?.backgroundColor,
+        color: data?.style?.textColor,
+        padding: data?.style?.padding,
+      }}
+    >
       <h3>{data.title}</h3>
       <p>Firstname: {data.firstName}</p>
       <p>Lastname: {data.lastName}</p>
@@ -19,24 +30,66 @@ const customContentPlugin: CellPlugin<{
   title: 'Custom content plugin',
   description: 'Some custom content plugin',
   version: 1,
-  controls: {
-    type: 'autoform',
-    schema: {
-      properties: {
-        title: {
-          type: 'string',
-          default: 'I am a custom plugin, this is my configuration',
-        },
-        firstName: { type: 'string' },
-        lastName: { type: 'string' },
-        age: {
-          title: 'Age in years',
-          type: 'integer',
-          minimum: 0,
+  controls: [
+    {
+      title: 'Default config',
+      controls: {
+        type: 'autoform',
+        schema: {
+          properties: {
+            title: {
+              type: 'string',
+              default: 'I am a custom plugin, this is my configuration',
+            },
+            firstName: { type: 'string' },
+            lastName: { type: 'string' },
+            age: {
+              title: 'Age in years',
+              type: 'integer',
+              minimum: 0,
+            },
+          },
+          required: ['firstName', 'lastName'],
         },
       },
-      required: ['firstName', 'lastName'],
     },
-  },
+    {
+      title: 'Styling',
+      controls: {
+        type: 'autoform',
+        schema: {
+          type: 'object',
+          required: [],
+          properties: {
+            style: {
+              type: 'object',
+              required: [],
+              properties: {
+                backgroundColor: {
+                  type: 'string',
+                  default: 'white',
+                  uniforms: {
+                    component: ColorPickerField,
+                  },
+                },
+                textColor: {
+                  type: 'string',
+                  default: 'black',
+                  uniforms: {
+                    component: ColorPickerField,
+                  },
+                },
+
+                padding: {
+                  type: 'number',
+                  default: 10,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  ],
 };
 export default customContentPlugin;

--- a/packages/editor/src/core/components/Cell/Inner/index.tsx
+++ b/packages/editor/src/core/components/Cell/Inner/index.tsx
@@ -6,6 +6,7 @@ import {
 import { getCellStyle } from '../../../utils/getCellStyle';
 import {
   useCellHasPlugin,
+  useCellStyle,
   useFocusCell,
   useIsEditMode,
   useIsFocused,
@@ -72,8 +73,8 @@ const Inner: React.FC<{ nodeId: string }> = ({ nodeId }) => {
   const insertAllowed = plugin?.childConstraints?.maxChildren
     ? plugin?.childConstraints?.maxChildren > childrenIds.length
     : true;
+  const cellStyle = useCellStyle(nodeId);
 
-  const cellStyle = getCellStyle(plugin);
   const children = childrenIds.map((id) => <Row nodeId={id} key={id} />);
   if (!cellShouldHavePlugin) {
     return <Droppable nodeId={nodeId}>{children}</Droppable>;

--- a/packages/editor/src/core/components/Cell/PluginComponent/index.tsx
+++ b/packages/editor/src/core/components/Cell/PluginComponent/index.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { BottomToolbar, AutoformControls } from '../../../../ui';
+import React, { useMemo } from 'react';
+import { BottomToolbar } from '../../../../ui';
 import { CellPluginComponentProps } from '../../../types';
 import {
   usePluginOfCell,
@@ -12,6 +12,7 @@ import {
   useOptions,
   useCellProps,
 } from '../../hooks';
+import PluginControls from '../PluginControls';
 import PluginMissing from '../PluginMissing';
 import NoopProvider from '../NoopProvider';
 
@@ -38,29 +39,32 @@ const PluginComponent: React.FC<{ nodeId: string; hasChildren: boolean }> = ({
 
   const Toolbar = useOptions().components?.BottomToolbar ?? BottomToolbar;
 
-  const componentProps: CellPluginComponentProps<unknown> = {
-    nodeId,
-    lang,
-    data,
-    pluginConfig: plugin,
-    focused: isEditMode && focused,
-    readOnly: !isEditMode,
-    onChange: onChange,
-    isEditMode,
-    isPreviewMode,
-    remove,
-  };
-
-  let pluginControls = null;
-  if (plugin?.controls?.type === 'custom') {
-    const { Component } = plugin.controls;
-    pluginControls = <Component {...componentProps} />;
-  }
-  if (plugin?.controls?.type === 'autoform') {
-    pluginControls = (
-      <AutoformControls {...componentProps} {...plugin.controls} />
-    );
-  }
+  const componentProps = useMemo<CellPluginComponentProps<unknown>>(
+    () => ({
+      nodeId,
+      lang,
+      data,
+      pluginConfig: plugin,
+      focused: isEditMode && focused,
+      readOnly: !isEditMode,
+      onChange: onChange,
+      isEditMode,
+      isPreviewMode,
+      remove,
+    }),
+    [
+      nodeId,
+      lang,
+      data,
+      plugin,
+      isEditMode,
+      focused,
+      onChange,
+      isEditMode,
+      isPreviewMode,
+      remove,
+    ]
+  );
 
   // In case of non-zero cell spacing, nested layouts (layout plugins with children) should have their
   // margin collapsing functionality off. The simplest solution is to use display:flex for the below wrapping <div>.
@@ -96,13 +100,14 @@ const PluginComponent: React.FC<{ nodeId: string; hasChildren: boolean }> = ({
         <Toolbar
           nodeId={nodeId}
           open={focused && isEditMode}
-          dark={plugin?.controls?.dark}
+          dark={plugin?.bottomToolbar?.dark}
           pluginControls={
-            <div
-              style={{ marginBottom: 12, maxHeight: '50vh', overflow: 'auto' }}
-            >
-              {pluginControls}
-            </div>
+            plugin?.controls ? (
+              <PluginControls
+                componentProps={componentProps}
+                controls={plugin?.controls}
+              />
+            ) : null
           }
         />
       </>

--- a/packages/editor/src/core/components/Cell/PluginControls/index.tsx
+++ b/packages/editor/src/core/components/Cell/PluginControls/index.tsx
@@ -1,0 +1,104 @@
+import { Tab, Tabs, Theme } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
+import React, { useState } from 'react';
+import { useMeasure } from 'react-use';
+import { AutoformControls } from '../../../../ui';
+import {
+  CellPluginComponentProps,
+  ControlsDef,
+  ControlsDefList,
+} from '../../../types';
+
+const StyledTab = withStyles(() => ({
+  wrapper: {
+    alignItems: 'flex-start',
+  },
+}))(Tab);
+
+const StyledTabs = withStyles((theme: Theme) => ({
+  root: {
+    marginTop: -12,
+    marginBottom: -12,
+    marginLeft: -24,
+    alignItems: 'flex-start',
+    backgroundColor: theme.palette.background.default,
+  },
+}))(Tabs);
+const ControlsList: React.FC<{
+  controls: ControlsDefList<unknown>;
+  componentProps: CellPluginComponentProps<unknown>;
+}> = React.memo(({ controls, componentProps }) => {
+  const [tab, setTab] = useState(0);
+
+  const activeControls = controls[tab]?.controls;
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+      }}
+    >
+      <StyledTabs
+        value={tab}
+        onChange={(e, v) => setTab(v)}
+        orientation="vertical"
+        variant="scrollable"
+      >
+        {controls.map((t, index) => (
+          <StyledTab label={t.title} key={index} />
+        ))}
+      </StyledTabs>
+
+      {activeControls ? (
+        <div
+          style={{
+            flex: 1,
+            marginLeft: 24,
+            display: 'flex',
+          }}
+        >
+          <Controls controls={activeControls} componentProps={componentProps} />
+        </div>
+      ) : null}
+    </div>
+  );
+});
+
+const Controls: React.FC<{
+  controls: ControlsDef<unknown>;
+  componentProps: CellPluginComponentProps<unknown>;
+}> = React.memo(({ controls, componentProps }) => {
+  let pluginControls = null;
+  if (Array.isArray(controls)) {
+    return <ControlsList componentProps={componentProps} controls={controls} />;
+  }
+
+  if (controls?.type === 'custom') {
+    const { Component } = controls;
+    pluginControls = <Component {...componentProps} {...controls} />;
+  } else if (controls?.type === 'autoform') {
+    pluginControls = <AutoformControls {...componentProps} {...controls} />;
+  }
+  return <div style={{ overflow: 'auto', flex: 1 }}>{pluginControls}</div>;
+});
+
+const PluginControls: React.FC<{
+  controls: ControlsDef<unknown>;
+  componentProps: CellPluginComponentProps<unknown>;
+}> = ({ controls, componentProps }) => {
+  return (
+    <div
+      style={{
+        maxHeight: '50vh',
+        // if it has tabs, stretch to avoid jumping tabs
+        width: Array.isArray(controls) ? '100vw' : undefined,
+        maxWidth: '100%',
+        display: 'flex',
+      }}
+    >
+      <Controls controls={controls} componentProps={componentProps} />
+    </div>
+  );
+};
+
+export default React.memo(PluginControls);

--- a/packages/editor/src/core/components/hooks/index.ts
+++ b/packages/editor/src/core/components/hooks/index.ts
@@ -6,3 +6,4 @@ export * from './actions';
 export * from './nodeActions';
 export * from './displayMode';
 export * from './dragDropActions';
+export * from './screen';

--- a/packages/editor/src/core/components/hooks/node.ts
+++ b/packages/editor/src/core/components/hooks/node.ts
@@ -7,6 +7,7 @@ import { findNodeInState } from '../../selector/editable';
 import { Cell, isRow, Node, Row } from '../../types/node';
 import deepEquals from '../../utils/deepEquals';
 import { getCellData } from '../../utils/getCellData';
+import { getCellStyle } from '../../utils/getCellStyle';
 import { getDropLevels } from '../../utils/getDropLevels';
 import { useUpdateCellData } from './nodeActions';
 import { useAllCellPlugins, useLang } from './options';
@@ -213,6 +214,24 @@ export const useCellData = (nodeId: string, lang?: string) => {
   const theLang = lang ?? currentLang;
 
   return useCellProps(nodeId, (c) => getCellData(c, theLang) ?? {});
+};
+
+/**
+ *returns the style of a cell if the plugin of th cell configures a custom style function
+ * @param nodeId a cell id
+ * @param lang a language key (optionally)
+ * @returns the data object in the given language of the given cell
+ */
+export const useCellStyle = (nodeId: string, lang?: string) => {
+  const plugin = usePluginOfCell(nodeId);
+
+  const currentLang = useLang();
+  const theLang = lang ?? currentLang;
+
+  return useCellProps(
+    nodeId,
+    (c) => getCellStyle(plugin, getCellData(c, theLang)) ?? {}
+  );
 };
 
 /**

--- a/packages/editor/src/core/components/hooks/screen.tsx
+++ b/packages/editor/src/core/components/hooks/screen.tsx
@@ -1,0 +1,6 @@
+import { useMediaQuery, useTheme } from '@material-ui/core';
+
+export const useIsSmallScreen = () => {
+  const theme = useTheme();
+  return useMediaQuery(theme.breakpoints.down('sm'));
+};

--- a/packages/editor/src/core/reducer/value/__tests__/initialReduced.test.ts
+++ b/packages/editor/src/core/reducer/value/__tests__/initialReduced.test.ts
@@ -1,5 +1,5 @@
 import { CellPlugin, Value } from '../../../types';
-import { createEditable } from '../../../utils/createEditable';
+import { createValue } from '../../../utils/createValue';
 import { simulateDispatch } from '../testUtils';
 //type State = { foo?: number; bar?: number };
 
@@ -18,7 +18,7 @@ const options = {
 
 describe('initial reduce (without actions)', () => {
   it('remove cells that have no rows and no plugin', () => {
-    const initialState = createEditable(
+    const initialState = createValue(
       {
         id: 'editableId',
         rows: [
@@ -67,7 +67,7 @@ describe('initial reduce (without actions)', () => {
     expect(actualState).toEqual(expectedState);
   });
   it('remove cells that have rows, but they are mepty and simplifies rows', () => {
-    const initialState = createEditable(
+    const initialState = createValue(
       {
         id: 'editableId',
         rows: [
@@ -174,7 +174,7 @@ describe('initial reduce (without actions)', () => {
 TODO: readd this tests
 
 test('insert cell right of, clean up tree afterwards', () => {
-  const initialState = createEditable('editable', [
+  const initialState = createValue('editable', [
     createCell('0', [
       createRow('00', [
         createCell('000', [
@@ -204,7 +204,7 @@ test('insert cell right of, clean up tree afterwards', () => {
     }
   );
 
-  const expectedState = createEditable(
+  const expectedState = createValue(
     'editable',
     _cells([
       createCell('0', [
@@ -221,7 +221,7 @@ test('insert cell right of, clean up tree afterwards', () => {
 });
 
 test('anti-recursion test: cell insert below of two level', () => {
-  const initialState = createEditable('editable', [
+  const initialState = createValue('editable', [
     createCell('0', [
       createRow('00', [
         createCell('000', [
@@ -251,7 +251,7 @@ test('anti-recursion test: cell insert below of two level', () => {
     }
   );
 
-  const expectedState = createEditable(
+  const expectedState = createValue(
     'editable',
     _cells([
       createCell(
@@ -274,7 +274,7 @@ test('anti-recursion test: cell insert below of two level', () => {
 });
 
 test('cell insert right of cell', () => {
-  const initialState = createEditable('editable', [
+  const initialState = createValue('editable', [
     createCell('0', [
       createRow('00', [createContentCell('000', 'foo')]),
       createRow('01', [createContentCell('010', 'bar')]),
@@ -292,7 +292,7 @@ test('cell insert right of cell', () => {
     }
   );
 
-  const expectedState = createEditable(
+  const expectedState = createValue(
     'editable',
     _cells([
       createCell('0', [
@@ -309,7 +309,7 @@ test('cell insert right of cell', () => {
 });
 
 test('cell insert below of cell - one level deep (row)', () => {
-  const initialState = createEditable('editable', [
+  const initialState = createValue('editable', [
     createCell('0', [
       createRow('00', [createContentCell('000', 'foo')]),
       createRow('01', [createContentCell('010', 'bar')]),
@@ -327,7 +327,7 @@ test('cell insert below of cell - one level deep (row)', () => {
     }
   );
 
-  const expectedState = createEditable(
+  const expectedState = createValue(
     'editable',
     _cells([
       createCell('0', [
@@ -346,7 +346,7 @@ test('cell insert below of cell - one level deep (row)', () => {
 });
 
 test('cell insert left of cell - one level deep (row)', () => {
-  const initialState = createEditable('editable', [
+  const initialState = createValue('editable', [
     createCell('0', [
       createRow('00', [createContentCell('000', 'foo')]),
       createRow('01', [createContentCell('010', 'bar')]),
@@ -364,7 +364,7 @@ test('cell insert left of cell - one level deep (row)', () => {
     }
   );
 
-  const expectedState = createEditable(
+  const expectedState = createValue(
     'editable',
     _cells([
       createCell('0', [
@@ -381,7 +381,7 @@ test('cell insert left of cell - one level deep (row)', () => {
 });
 
 test('cell insert left of cell', () => {
-  const initialState = createEditable('editable', [
+  const initialState = createValue('editable', [
     createCell('0', [
       createRow('00', [createContentCell('000', 'foo')]),
       createRow('01', [createContentCell('010', 'bar')]),
@@ -399,7 +399,7 @@ test('cell insert left of cell', () => {
     }
   );
 
-  const expectedState = createEditable(
+  const expectedState = createValue(
     'editable',
     _cells([
       createCell('0', [
@@ -416,7 +416,7 @@ test('cell insert left of cell', () => {
 });
 
 test('cell insert above cell', () => {
-  const initialState = createEditable('editable', [
+  const initialState = createValue('editable', [
     createCell('0', [
       createRow('00', [createContentCell('000', 'foo')]),
       createRow('01', [createContentCell('010', 'bar')]),
@@ -434,7 +434,7 @@ test('cell insert above cell', () => {
     }
   );
 
-  const expectedState = createEditable(
+  const expectedState = createValue(
     'editable',
     _cells([
       createCell('0', [
@@ -453,7 +453,7 @@ test('cell insert above cell', () => {
 });
 
 test('cell insert below cell', () => {
-  const initialState = createEditable('editable', [
+  const initialState = createValue('editable', [
     createCell('0', [
       createRow('00', [createContentCell('000', 'foo')]),
       createRow('01', [createContentCell('010', 'bar')]),
@@ -471,7 +471,7 @@ test('cell insert below cell', () => {
     }
   );
 
-  const expectedState = createEditable(
+  const expectedState = createValue(
     'editable',
     _cells([
       createCell('0', [
@@ -490,7 +490,7 @@ test('cell insert below cell', () => {
 });
 
 test('cell move below another cell', () => {
-  const initialState = createEditable('editable', [
+  const initialState = createValue('editable', [
     createCell('0', [
       createRow('00', [createContentCell('000', 'foo')]),
       createRow('01', [createContentCell('010', 'bar')]),
@@ -508,7 +508,7 @@ test('cell move below another cell', () => {
     }
   );
 
-  const expectedState = createEditable(
+  const expectedState = createValue(
     'editable',
     _cells([
       createCell('0', [
@@ -522,7 +522,7 @@ test('cell move below another cell', () => {
 });
 
 test('cell insert inline cell left of', () => {
-  const initialState = createEditable('editable', [
+  const initialState = createValue('editable', [
     createCell('0', [
       createRow('00', [
         createContentCell('000', 'foo'),
@@ -542,7 +542,7 @@ test('cell insert inline cell left of', () => {
     }
   );
 
-  const expectedState = createEditable(
+  const expectedState = createValue(
     'editable',
     _cells([
       createCell('0', [
@@ -572,7 +572,7 @@ test('cell insert inline cell left of', () => {
 });
 
 test('move inline cell from left to right', () => {
-  const initialState = createEditable('editable', [
+  const initialState = createValue('editable', [
     createCell('0', [
       createRow('00', [
         createContentCell('000', 'foo', null, { inline: 'left' }),
@@ -592,7 +592,7 @@ test('move inline cell from left to right', () => {
     }
   );
 
-  const expectedState = createEditable(
+  const expectedState = createValue(
     'editable',
     _cells([
       createCell('0', [
@@ -608,7 +608,7 @@ test('move inline cell from left to right', () => {
 });
 
 test('cell insert cell left of inline row', () => {
-  const initialState = createEditable('editable', [
+  const initialState = createValue('editable', [
     createCell('0', [
       createRow('00', [
         createContentCell('000', 'foo', null, { inline: 'left' }),
@@ -628,7 +628,7 @@ test('cell insert cell left of inline row', () => {
     }
   );
 
-  const expectedState = createEditable(
+  const expectedState = createValue(
     'editable',
     _cells([
       createContentCell('id-item', 'myPlugin', null, { size: 6 }),
@@ -645,7 +645,7 @@ test('cell insert cell left of inline row', () => {
 });
 
 test('cell insert below inline row', () => {
-  const initialState = createEditable('editable', [
+  const initialState = createValue('editable', [
     createCell('0', [
       createRow('00', [
         createContentCell('000', 'foo', null, { inline: 'left' }),
@@ -665,7 +665,7 @@ test('cell insert below inline row', () => {
     }
   );
 
-  const expectedState = createEditable(
+  const expectedState = createValue(
     'editable',
     _cells([
       createCell('0', [
@@ -684,7 +684,7 @@ test('cell insert below inline row', () => {
 });
 
 test('cell insert below inline row - 2 level', () => {
-  const initialState = createEditable('editable', [
+  const initialState = createValue('editable', [
     createCell('0', [
       createRow('00', [
         createContentCell('000', 'foo', null, { inline: 'left' }),
@@ -704,7 +704,7 @@ test('cell insert below inline row - 2 level', () => {
     }
   );
 
-  const expectedState = createEditable(
+  const expectedState = createValue(
     'editable',
     _cells([
       createCell(

--- a/packages/editor/src/core/reducer/value/__tests__/removeCell.test.ts
+++ b/packages/editor/src/core/reducer/value/__tests__/removeCell.test.ts
@@ -1,6 +1,6 @@
 import { CellPlugin, Value } from '../../../types';
 import { removeCell } from '../../../actions/cell';
-import { createEditable } from '../../../utils/createEditable';
+import { createValue } from '../../../utils/createValue';
 import { simulateDispatch } from '../testUtils';
 
 const cellPlugins: CellPlugin[] = [
@@ -17,7 +17,7 @@ const options = {
 };
 describe('remove cell', () => {
   it('removes cell by id', () => {
-    const initialState = createEditable(
+    const initialState = createValue(
       {
         id: 'editableId',
         rows: [

--- a/packages/editor/src/core/reducer/value/__tests__/resizeCell.test.ts
+++ b/packages/editor/src/core/reducer/value/__tests__/resizeCell.test.ts
@@ -1,6 +1,6 @@
 import { CellPlugin, Value } from '../../../types';
 import { resizeCell } from '../../../actions/cell';
-import { createEditable } from '../../../utils/createEditable';
+import { createValue } from '../../../utils/createValue';
 import { simulateDispatch } from '../testUtils';
 
 const cellPlugins: CellPlugin[] = [
@@ -18,7 +18,7 @@ const options = {
 
 describe('resizeCell', () => {
   it('resizes siblings', () => {
-    const initialState = createEditable(
+    const initialState = createValue(
       {
         id: 'editableId',
         rows: [
@@ -84,7 +84,7 @@ describe('resizeCell', () => {
   });
 
   it('resizes inline cells', () => {
-    const initialState = createEditable(
+    const initialState = createValue(
       {
         id: 'editableId',
         rows: [

--- a/packages/editor/src/core/reducer/value/__tests__/updateCellContent.test.ts
+++ b/packages/editor/src/core/reducer/value/__tests__/updateCellContent.test.ts
@@ -1,6 +1,6 @@
 import { CellPlugin, Value } from '../../../types';
 import { updateCellData } from '../../../actions/cell';
-import { createEditable } from '../../../utils/createEditable';
+import { createValue } from '../../../utils/createValue';
 import { simulateDispatch } from '../testUtils';
 
 const cellPlugins: CellPlugin[] = [
@@ -18,7 +18,7 @@ const options = {
 
 describe('updateCellData', () => {
   it('updates cell data in the given language', () => {
-    const initialState = createEditable(
+    const initialState = createValue(
       {
         id: 'editableId',
         rows: [
@@ -79,7 +79,7 @@ describe('updateCellData', () => {
   });
 
   it('adds a new language field', () => {
-    const initialState = createEditable(
+    const initialState = createValue(
       {
         id: 'editableId',
         rows: [

--- a/packages/editor/src/core/types/jsonSchema.ts
+++ b/packages/editor/src/core/types/jsonSchema.ts
@@ -112,7 +112,7 @@ export type JsonSchema<T extends Record<string, unknown> | unknown> = {
   /**
    * child properties of this object
    */
-  properties: { [K in keyof T]-?: JsonSchemaProperty<T[K]> };
+  properties: { [K in keyof T]?: JsonSchemaProperty<T[K]> };
   // required: string[];
   /* union to tuple conversion is expensive, we do a poor mans version here */
   /**

--- a/packages/editor/src/core/types/plugins.ts
+++ b/packages/editor/src/core/types/plugins.ts
@@ -5,7 +5,7 @@ import { Cell, CellSpacing, PartialCell, PartialRow } from './node';
 import { JsonSchema } from './jsonSchema';
 import { ChildConstraints } from './constraints';
 
-export type CellPluginComponentProps<DataT> = {
+export type CellPluginComponentProps<DataT = unknown> = {
   /**
    * the cells nodeId
    */
@@ -97,13 +97,20 @@ export type AutoformControlsDef<DataT> = {
   type: 'autoform';
 };
 
+export type SubControlsDef<T> = {
+  title: string;
+  controls: ControlsDef<T>;
+};
+
+export type ControlsDefList<DataT> = Array<SubControlsDef<Partial<DataT>>>;
+
 /**
  * All available type of controls
  */
-export type ControlsDef<DataT> = { dark?: boolean } & (
+export type ControlsDef<DataT> =
   | AutoformControlsDef<DataT>
   | CustomControlsDef<DataT>
-);
+  | ControlsDefList<DataT>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type CellPlugin<DataT = unknown, DataSerializedT = DataT> = {
   /**
@@ -145,6 +152,15 @@ export type CellPlugin<DataT = unknown, DataSerializedT = DataT> = {
   migrations?: Migration[];
 
   /**
+   * customize the bottom toolbar
+   */
+  bottomToolbar?: {
+    /**
+     * whether to display the bottom toolbar in dark theme
+     */
+    dark?: boolean;
+  };
+  /**
    * controls define how the user can interact with this cell. @see ControlsDef
    */
   controls?: ControlsDef<DataT>;
@@ -173,7 +189,7 @@ export type CellPlugin<DataT = unknown, DataSerializedT = DataT> = {
   /**
    * additional style for the wrapping cell
    */
-  cellStyle?: React.CSSProperties | (() => React.CSSProperties);
+  cellStyle?: React.CSSProperties | ((data: DataT) => React.CSSProperties);
 
   /**
    * cell spacing setting for the internal layout (nested cells) if any

--- a/packages/editor/src/core/utils/createValue.ts
+++ b/packages/editor/src/core/utils/createValue.ts
@@ -3,12 +3,12 @@ import { CURRENT_EDITABLE_VERSION } from '../migrations/EDITABLE_MIGRATIONS';
 import { Value, PartialRow } from '../types/node';
 import { createId } from './createId';
 
-type PartialEditable = {
+type PartialValue = {
   id?: string;
   rows?: PartialRow[];
 };
-export const createEditable = (
-  partial: PartialEditable,
+export const createValue = (
+  partial: PartialValue,
   options: PluginsAndLang
 ): Value => {
   return {

--- a/packages/editor/src/core/utils/getCellStyle.ts
+++ b/packages/editor/src/core/utils/getCellStyle.ts
@@ -1,8 +1,8 @@
 import { CellPlugin } from '../types';
 
-export const getCellStyle = (plugin: CellPlugin) =>
+export const getCellStyle = (plugin: CellPlugin, data: unknown) =>
   plugin?.cellStyle
     ? typeof plugin?.cellStyle === 'function'
-      ? plugin?.cellStyle()
+      ? plugin?.cellStyle(data)
       : plugin?.cellStyle
     : undefined;

--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -12,11 +12,12 @@ import makeUniformsSchema from './ui/AutoformControls/makeUniformsSchema';
 import { migrateValue } from './core/migrations/migrate';
 import deepEquals from './core/utils/deepEquals';
 
+import { createValue } from './core/utils/createValue';
 export { lazyLoad };
 export { EditorProps };
 export { Migration };
 export { makeUniformsSchema };
-
+export { createValue };
 export { migrateValue };
 
 export { deepEquals };

--- a/packages/editor/src/renderer/HTMLRenderer.tsx
+++ b/packages/editor/src/renderer/HTMLRenderer.tsx
@@ -84,9 +84,9 @@ const HTMLCell: React.FC<
     : null;
   if (plugin) {
     const { Renderer } = plugin;
-    const cellStyle = getCellStyle(plugin);
+    const data = getCellData(cell, lang) ?? {};
+    const cellStyle = getCellStyle(plugin, data);
     const Provider = plugin.Provider ?? NoopProvider;
-    const data = getCellData(cell, lang);
 
     let pluginCellSpacing = getPluginCellSpacing(plugin, data);
     if (typeof pluginCellSpacing === 'undefined' || pluginCellSpacing == null) {

--- a/packages/editor/src/ui/AutoformControls/index.tsx
+++ b/packages/editor/src/ui/AutoformControls/index.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment, useEffect, useMemo } from 'react';
 import JSONSchemaBridge from 'uniforms-bridge-json-schema';
+import { useIsSmallScreen } from '../../core/components/hooks';
 import lazyLoad from '../../core/helper/lazyLoad';
 
 import {
@@ -44,11 +45,12 @@ export function AutoformControls<T extends Record<string, unknown> | unknown>({
     };
     onChange(newDefaultData);
   }, [bridge]);
+  const isSmall = useIsSmallScreen();
   return (
     <AutoForm model={data} autosave={true} schema={bridge} onSubmit={onChange}>
       <div
         style={{
-          columnCount: columnCount,
+          columnCount: isSmall ? 1 : columnCount,
           columnRule: '1px solid #E0E0E0',
           columnGap: 48,
         }}

--- a/packages/editor/src/ui/BottomToolbar/Drawer.tsx
+++ b/packages/editor/src/ui/BottomToolbar/Drawer.tsx
@@ -1,6 +1,6 @@
-import { Portal, Drawer, DrawerProps, Divider } from '@material-ui/core';
-
+import { Divider, Drawer, DrawerProps, Portal } from '@material-ui/core';
 import React, { Fragment } from 'react';
+import { useIsSmallScreen } from '../../core/components/hooks';
 
 const darkBlack = 'rgba(0, 0, 0, 0.87)';
 const bright = 'rgba(255,255,255, 0.98)';
@@ -14,6 +14,7 @@ export type BottomToolbarDrawerProps = {
   dark?: boolean;
   scale?: number;
 };
+
 export const BottomToolbarDrawer: React.FC<BottomToolbarDrawerProps> = ({
   className,
   anchor,
@@ -35,7 +36,7 @@ export const BottomToolbarDrawer: React.FC<BottomToolbarDrawerProps> = ({
   );
 
   const theChildren = React.Children.toArray(children).filter(Boolean);
-
+  const isSmall = useIsSmallScreen();
   return (
     <Portal>
       <Drawer
@@ -65,14 +66,23 @@ export const BottomToolbarDrawer: React.FC<BottomToolbarDrawerProps> = ({
             backgroundColor: dark ? darkBlack : bright,
             padding: '12px 24px',
 
-            margin: 'auto',
+            ...(isSmall
+              ? {
+                  marginLeft: 20,
+                  marginRight: 80,
+                }
+              : {
+                  marginLeft: 'auto',
+                  marginRight: 'auto',
+                  minWidth: '50vw',
+                  maxWidth: 'min(1280px, calc(100vw - 250px))',
+                }),
             boxShadow: '0px 1px 8px -1px rgba(0,0,0,0.4)',
             position: 'relative',
-            minWidth: '50vw',
-            maxWidth: 'calc(100vw - 220px)',
+
             transformOrigin: 'bottom',
             transform: `scale(${scale})`,
-            transition: '0.3s',
+            transition: 'scale 0.3s',
             ...style,
           }}
         >

--- a/packages/editor/src/ui/ColorPicker/ColorPickerField.tsx
+++ b/packages/editor/src/ui/ColorPicker/ColorPickerField.tsx
@@ -5,11 +5,14 @@ import { colorToString, stringToColor } from './colorToString';
 
 const ColorPickerField = connectField<{
   value: string;
+  label: string;
   onChange: (v: string) => void;
 }>((props) => {
   return (
     <ColorPicker
+      style={{ marginBottom: 8 }}
       color={stringToColor(props.value)}
+      buttonContent={props.label}
       onChange={(v) => {
         props.onChange(colorToString(v));
       }}

--- a/packages/editor/src/ui/DisplayModeToggle/Button/index.tsx
+++ b/packages/editor/src/ui/DisplayModeToggle/Button/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import Fab from '@material-ui/core/Fab';
 
-import { useTheme, useMediaQuery, PropTypes } from '@material-ui/core';
+import { PropTypes } from '@material-ui/core';
+import { useIsSmallScreen } from '../../../core/components/hooks';
 
 const DisplayModeToggle = ({
   description,
@@ -20,14 +21,13 @@ const DisplayModeToggle = ({
   onClick: React.MouseEventHandler<HTMLElement>;
   style?: React.CSSProperties;
 }) => {
-  const theme = useTheme();
-  const isLarge = useMediaQuery(theme.breakpoints.up('sm'));
+  const isSmall = useIsSmallScreen();
   return (
     <div className="react-page-controls-mode-toggle-button" style={style}>
       <div className="react-page-controls-mode-toggle-button-inner">
         <Fab
           color={active ? activeColor : 'default'}
-          size={isLarge ? 'large' : 'small'}
+          size={isSmall ? 'small' : 'large'}
           onClick={onClick}
           disabled={disabled}
         >

--- a/packages/editor/src/ui/DisplayModeToggle/UndoRedo/index.tsx
+++ b/packages/editor/src/ui/DisplayModeToggle/UndoRedo/index.tsx
@@ -8,6 +8,7 @@ import {
   useCanUndo,
   useCanRedo,
   useUndo,
+  useIsSmallScreen,
 } from '../../../core/components/hooks';
 import Button from '../Button/index';
 
@@ -20,10 +21,11 @@ const UndoRedo: React.FC<Props> = ({ labelUndo, labelRedo }) => {
   const canUndo = useCanUndo();
   const canRedo = useCanRedo();
   const redo = useRedo();
+  const isSmall = useIsSmallScreen();
   return (
     <div
       style={{
-        height: 80,
+        height: isSmall ? 56 : 80,
         float: 'right',
         display: 'flex',
         direction: 'ltr',
@@ -32,18 +34,22 @@ const UndoRedo: React.FC<Props> = ({ labelUndo, labelRedo }) => {
     >
       <div
         style={{
-          width: 36,
+          width: isSmall ? 29 : 36,
           overflow: 'hidden',
-          marginRight: 2,
+          marginRight: isSmall ? 1 : 2,
         }}
       >
         <Button
           active
           disabled={!canUndo}
           style={{
-            transform: 'translateX(35px)',
+            transform: `translateX(${isSmall ? 27 : 35}px)`,
           }}
-          icon={<IconUndo style={{ transform: 'translateX(-12px)' }} />}
+          icon={
+            <IconUndo
+              style={{ transform: `translateX(-${isSmall ? 6 : 12}px)` }}
+            />
+          }
           description={labelUndo}
           onClick={undo}
           activeColor="primary"
@@ -51,7 +57,7 @@ const UndoRedo: React.FC<Props> = ({ labelUndo, labelRedo }) => {
       </div>
       <div
         style={{
-          width: 36,
+          width: isSmall ? 28 : 36,
           overflow: 'hidden',
           marginLeft: 1,
         }}
@@ -63,7 +69,11 @@ const UndoRedo: React.FC<Props> = ({ labelUndo, labelRedo }) => {
           }}
           active
           disabled={!canRedo}
-          icon={<IconRedo style={{ transform: 'translateX(12px)' }} />}
+          icon={
+            <IconRedo
+              style={{ transform: `translateX(${isSmall ? 6 : 12}px)` }}
+            />
+          }
           description={labelRedo}
           onClick={redo}
           activeColor="primary"

--- a/packages/plugins/content/divider/src/createPlugin.tsx
+++ b/packages/plugins/content/divider/src/createPlugin.tsx
@@ -7,9 +7,7 @@ import { DividerSettings } from './types/settings';
 
 const Remove = lazyLoad(() => import('@material-ui/icons/Remove'));
 
-const createPlugin: (settings: DividerSettings) => CellPlugin<void> = (
-  settings
-) => {
+const createPlugin: (settings: DividerSettings) => CellPlugin = (settings) => {
   const mergedSettings = { ...defaultSettings, ...settings };
   return {
     Renderer: settings.Renderer || DividerHtmlRenderer,

--- a/packages/plugins/content/divider/src/types/settings.ts
+++ b/packages/plugins/content/divider/src/types/settings.ts
@@ -2,6 +2,6 @@ import { CellPluginComponentProps } from '@react-page/editor';
 import { Translations } from './translations';
 
 export interface DividerSettings {
-  Renderer: React.ComponentType<CellPluginComponentProps<void>>;
+  Renderer: React.ComponentType<CellPluginComponentProps>;
   translations?: Translations;
 }

--- a/packages/plugins/content/slate/src/index.tsx
+++ b/packages/plugins/content/slate/src/index.tsx
@@ -122,9 +122,11 @@ function plugin<TPlugins extends SlatePluginCollection = DefaultPlugins>(
         defaultPluginType={settings.defaultPluginType}
       />
     ),
+    bottomToolbar: {
+      dark: true,
+    },
     controls: {
       type: 'custom',
-      dark: true,
       Component: (props) => (
         <Controls
           {...props}


### PR DESCRIPTION
This PR adds the ability to specify multiple controls on a plugin. 
This solves two problems:

- better organization of cell controls if there are a lot of properties
- Make it possible to add functionality to all plugins (see https://github.com/react-page/react-page/issues/904)

E.g. its possible to add padding controls to all plugins:


<img width="904" alt="Bildschirmfoto 2021-03-26 um 12 12 52" src="https://user-images.githubusercontent.com/1972353/112623405-9a198100-8e2c-11eb-842b-ef8ea1cefa20.png">

<img width="904" alt="Bildschirmfoto 2021-03-26 um 12 13 42" src="https://user-images.githubusercontent.com/1972353/112623494-b6b5b900-8e2c-11eb-8d2a-14ac78218b67.png">

I decided to use vertical tabs, because vertical space is rare in the bottom toolbar. Having the tabs on the left saves us some space.

This PR additional fixes some styling problems on mobile and adds documentation about the new feature (+ some undocumented stuff)

