### PR TITLE
bug(ui): trouble focusing the Background plugin

### DIFF
--- a/packages/editor/src/core/components/Cell/Inner/index.tsx
+++ b/packages/editor/src/core/components/Cell/Inner/index.tsx
@@ -34,23 +34,19 @@ const Inner: React.FC<{ nodeId: string }> = ({ nodeId }) => {
       const target = e.target as HTMLDivElement;
 
       // check whether the click was inside cell-inner, but not inside a nested cell
-      // also check whether it was not somehwere in a inner row (e.g. the resize handle)
       if (
+        !focused &&
+        isEditMode &&
+        // this arrives when they stop resizing
+        !target.classList.contains('react-page-row') &&
         target?.closest &&
         target.closest('.react-page-cell-inner') === ref.current &&
-        target.closest('.react-page-cell') ===
-          ref.current.closest('.react-page-cell') &&
-        target.closest('.react-page-row') ===
-          ref.current.closest('.react-page-row') &&
-        // also prevent click on insert new
-        !target.classList.contains('react-page-cell-insert-new')
+        target.closest('.react-page-cell.react-page-cell-has-plugin') ===
+          ref.current.closest('.react-page-cell')
       ) {
-        if (!focused && isEditMode) {
-          focus(false, 'onClick');
-          setEditMode();
-        }
+        focus(false, 'onClick');
+        setEditMode();
       }
-      return true;
     },
     [focus, focused, isEditMode, setEditMode]
   );

--- a/packages/editor/src/core/components/Cell/InsertNew.tsx
+++ b/packages/editor/src/core/components/Cell/InsertNew.tsx
@@ -45,6 +45,7 @@ const InsertNew: React.FC<{ parentCellId?: string }> = ({ parentCellId }) => {
         margin: 'auto',
       }}
       onClick={(e) => {
+        e.stopPropagation();
         setReferenceNodeId(parentCellId);
         setInsertMode();
       }}

--- a/packages/editor/src/core/components/Cell/index.tsx
+++ b/packages/editor/src/core/components/Cell/index.tsx
@@ -127,7 +127,7 @@ const Cell: React.FC<Props> = ({ nodeId, measureRef }) => {
             !isResizeMode && !isLayoutMode && inline, // inline must not be active for resize/layout
         }
       )}
-      onClick={stopClick(isEditMode)}
+      onClick={stopClick(hasPlugin && isEditMode)}
     >
       <Handle nodeId={nodeId} />
       <div

--- a/packages/editor/src/core/components/Row/ResizableRowCell.tsx
+++ b/packages/editor/src/core/components/Row/ResizableRowCell.tsx
@@ -77,6 +77,7 @@ const ResizableRowCell: React.FC<Props> = ({
               // fix floating style
               height: rowHasInlineChildrenPosition ? cellHeight : 'auto',
             }}
+            onClick={(e) => e.stopPropagation()}
           ></div>
         </Draggable>
       ) : null}

--- a/packages/editor/src/core/components/Row/index.tsx
+++ b/packages/editor/src/core/components/Row/index.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import React from 'react';
 import { useMeasure } from 'react-use';
 import { isRow, Node, Row } from '../../types/node';
-import { useBlurAllCells, useNodeHoverPosition, useNodeProps } from '../hooks';
+import { useNodeHoverPosition, useNodeProps } from '../hooks';
 import Droppable from './Droppable';
 import ResizableRowCell from './ResizableRowCell';
 
@@ -30,7 +30,6 @@ const reduceToIdAndSizeArray = (
 const Row: React.FC<{ nodeId: string }> = ({ nodeId }) => {
   const [ref, { width: rowWidth }] = useMeasure();
 
-  const blurAllCells = useBlurAllCells();
   const hoverPosition = useNodeHoverPosition(nodeId);
 
   const childrenWithOffsets = useNodeProps(nodeId, (node) =>
@@ -57,8 +56,7 @@ const Row: React.FC<{ nodeId: string }> = ({ nodeId }) => {
             rowHasInlineChildrenPosition
           ),
         })}
-        style={{ position: 'relative', borderColor: 'red' }}
-        onClick={blurAllCells}
+        style={{ position: 'relative' }}
       >
         {childrenWithOffsets.map(({ offset, id, size, maxSize }, index) => (
           <ResizableRowCell


### PR DESCRIPTION
Allow clicks on layout plugin body to bubble up and be caught by the focusing logic.
Prevent blurAll when clicking on resize handle or when done resizing.

## Proposed changes

Stop propagation in their respective elements.
Handle phantom onClick for "react-page-row" separately -- that event is being fired when resizing stops.
Remove blurAll from the row (it was hit by the phantom onClick).

## Types of changes

<!-- What types of changes does your code introduce to react-page? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Closing issues

#945
