### PR TITLE
fix: react version below 16.14. does no longer work

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -9,8 +9,8 @@
     "start": "next start"
   },
   "peerDependencies": {
-    "react": "^16.8.6 || ^17.0.0",
-    "react-dom": "^16.8.6 || ^17.0.'"
+    "react": ">= 16.14",
+    "react-dom": ">= 16.14"
   },
   "dependencies": {
     "@material-ui/core": "^4.11.2",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -21,8 +21,8 @@
     "clean": "rimraf \"lib\" && rimraf \"lib-es\" && rm -f *.tsbuildinfo"
   },
   "peerDependencies": {
-    "react": "^16.8.6 || ^17.0.0",
-    "react-dom": "^16.8.6 || ^17.0.0"
+    "react": ">= 16.14",
+    "react-dom": ">= 16.14"
   },
   "dependencies": {
     "ajv": "^7.1.1",

--- a/packages/plugins/content/divider/package.json
+++ b/packages/plugins/content/divider/package.json
@@ -19,8 +19,8 @@
     "clean": "rimraf \"lib\" && rimraf \"lib-es\" && rm -f *.tsbuildinfo"
   },
   "peerDependencies": {
-    "react": "^16.8.6 || ^17.0.0",
-    "react-dom": "^16.8.6"
+    "react": ">= 16.14",
+    "react-dom": ">= 16.14"
   },
   "dependencies": {
     "@material-ui/icons": "^4.2.1",

--- a/packages/plugins/content/html5-video/package.json
+++ b/packages/plugins/content/html5-video/package.json
@@ -19,8 +19,8 @@
     "clean": "rimraf \"lib\" && rimraf \"lib-es\" && rm -f *.tsbuildinfo"
   },
   "peerDependencies": {
-    "react": "^16.8.6 || ^17.0.0",
-    "react-dom": "^16.8.6 || ^17.0.0",
+    "react": ">= 16.14",
+    "react-dom": ">= 16.14",
     "@material-ui/core": "*",
     "@material-ui/icons": "*",
     "@material-ui/styles": "*"

--- a/packages/plugins/content/image/package.json
+++ b/packages/plugins/content/image/package.json
@@ -18,8 +18,8 @@
     "clean": "rimraf \"lib\" && rimraf \"lib-es\" && rm -f *.tsbuildinfo"
   },
   "peerDependencies": {
-    "react": "^16.8.6 || ^17.0.0",
-    "react-dom": "^16.8.6 || ^17.0.0",
+    "react": ">= 16.14",
+    "react-dom": ">= 16.14",
     "@material-ui/core": "*",
     "@material-ui/icons": "*",
     "@material-ui/styles": "*"

--- a/packages/plugins/content/slate/package.json
+++ b/packages/plugins/content/slate/package.json
@@ -21,8 +21,8 @@
     "clean": "rimraf \"lib\" && rimraf \"lib-es\" && rm -f *.tsbuildinfo"
   },
   "peerDependencies": {
-    "react": "^16.8.6 || ^17.0.0",
-    "react-dom": "^16.8.6 || ^17.0.0",
+    "react": ">= 16.14",
+    "react-dom": ">= 16.14",
     "@material-ui/core": "*",
     "@material-ui/icons": "*"
   },

--- a/packages/plugins/content/spacer/package.json
+++ b/packages/plugins/content/spacer/package.json
@@ -18,8 +18,8 @@
     "clean": "rimraf \"lib\" && rimraf \"lib-es\" && rm -f *.tsbuildinfo"
   },
   "peerDependencies": {
-    "react": "^16.8.6 || ^17.0.0",
-    "react-dom": "^16.8.6 || ^17.0.0",
+    "react": ">= 16.14",
+    "react-dom": ">= 16.14",
     "@material-ui/core": "*",
     "@material-ui/icons": "*",
     "@material-ui/styles": "*"

--- a/packages/plugins/content/video/package.json
+++ b/packages/plugins/content/video/package.json
@@ -18,8 +18,8 @@
     "clean": "rimraf \"lib\" && rimraf \"lib-es\" && rm -f *.tsbuildinfo"
   },
   "peerDependencies": {
-    "react": "^16.8.6 || ^17.0.0",
-    "react-dom": "^16.8.6 || ^17.0.0",
+    "react": ">= 16.14",
+    "react-dom": ">= 16.14",
     "@material-ui/core": "*",
     "@material-ui/icons": "*",
     "@material-ui/styles": "*"

--- a/packages/plugins/createPluginMaterialUi/package.json
+++ b/packages/plugins/createPluginMaterialUi/package.json
@@ -18,8 +18,8 @@
   "peerDependencies": {
     "@material-ui/core": "*",
     "@material-ui/icons": "*",
-    "react": "^16.8.6 || ^17.0.0",
-    "react-dom": "^16.8.6"
+    "react": ">= 16.14",
+    "react-dom": ">= 16.14"
   },
   "dependencies": {
     "@react-page/editor": "0.0.0",

--- a/packages/plugins/layout/background/package.json
+++ b/packages/plugins/layout/background/package.json
@@ -17,8 +17,8 @@
     "clean": "rimraf \"lib\" && rimraf \"lib-es\" && rm -f *.tsbuildinfo"
   },
   "peerDependencies": {
-    "react": "^16.8.6 || ^17.0.0",
-    "react-dom": "^16.8.6 || ^17.0.0",
+    "react": ">= 16.14",
+    "react-dom": ">= 16.14",
     "@material-ui/core": "*",
     "@material-ui/icons": "*",
     "@material-ui/styles": "*"

--- a/packages/react-admin/package.json
+++ b/packages/react-admin/package.json
@@ -18,8 +18,8 @@
     "@material-ui/core": "*",
     "@material-ui/icons": "*",
     "react-final-form": "*",
-    "react": "^16.8.6 || ^17.0.0",
-    "react-dom": "^16.8.6",
+    "react": ">= 16.14",
+    "react-dom": ">= 16.14",
     "react-admin": "^3.0.0",
     "uniforms": "*"
   },


### PR DESCRIPTION
this is because react-dnd requires react 16.14 as min version. It should be usually safe to upgrade react to 16.14 or even 17.

fixes https://github.com/react-page/react-page/issues/961

