### PR TITLE
fix/962: restore background dragging + dragging by handle styles

### DIFF
--- a/packages/editor/src/core/components/Cell/Draggable/index.css
+++ b/packages/editor/src/core/components/Cell/Draggable/index.css
@@ -110,7 +110,9 @@
       z-index: 4;
     }
 
-    .react-page-cell-draggable-is-dragging {
+    .react-page-cell-draggable-is-dragging,
+    .react-page-cell-handle-is-dragging + div > .react-page-cell-droppable > .react-page-cell-draggable,
+    .react-page-cell-handle-is-dragging + div > .react-page-cell-droppable > .react-page-cell-draggable-in-edit {
       opacity: 0.4;
       outline: none;
     }

--- a/packages/editor/src/core/components/Cell/Draggable/index.tsx
+++ b/packages/editor/src/core/components/Cell/Draggable/index.tsx
@@ -34,20 +34,20 @@ const Draggable: React.FC<Props> = ({ isLeaf, children, nodeId }) => {
     <>
       {previewElement}
       <div
+        ref={isLayoutMode ? dragRef : undefined}
         style={{
           height: '100%',
         }}
         className={classNames({
-          'react-page-cell-draggable-in-edit': options.allowMoveInEditMode,
-          'react-page-cell-draggable':
-            isLayoutMode && !options.allowMoveInEditMode,
+          'react-page-cell-draggable-in-edit':
+            !isLayoutMode && options.allowMoveInEditMode,
+          'react-page-cell-draggable': isLayoutMode,
           'react-page-cell-draggable-is-dragging': isDragging,
         })}
         onMouseDown={(e) => e.stopPropagation()}
       >
         {isLayoutMode ? (
           <div
-            ref={dragRef}
             className={classNames({
               'react-page-cell-draggable-overlay': isLayoutMode,
               [`react-page-cell-draggable-inline-${cell.inline}`]: cell.inline,

--- a/packages/editor/src/core/components/Cell/Handle/index.tsx
+++ b/packages/editor/src/core/components/Cell/Handle/index.tsx
@@ -29,6 +29,7 @@ const Handle: React.FC<{ nodeId: string }> = ({ nodeId }) => {
       <div
         className={classNames('react-page-cell-handle', {
           'react-page-cell-handle-drag-enabled': dragEnabled,
+          'react-page-cell-handle-is-dragging': isDragging,
         })}
         ref={dragRef}
         onClick={() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Proposed changes

Fixes a problem with background plugins not responding to dragging in layout mode.
Also adds styles for highlighting a cell that is dragged by the cell handle.

## Types of changes

<!-- What types of changes does your code introduce to react-page? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Closing issues

Closes #962
