### PR TITLE
feat(CellPlugin): autoform controls now allows custom layouts

### DIFF
--- a/examples/pages/examples/customformlayout.tsx
+++ b/examples/pages/examples/customformlayout.tsx
@@ -1,0 +1,99 @@
+import React, { useState } from 'react';
+import { AutoFields, ColorPickerField } from '@react-page/editor';
+// The editor core
+import type { Value, CellPlugin } from '@react-page/editor';
+import Editor, { createValue } from '@react-page/editor';
+
+// import the main css, uncomment this: (this is commented in the example because of https://github.com/vercel/next.js/issues/19717)
+// import '@react-page/editor/lib/index.css';
+
+// The rich text area plugin
+import slate from '@react-page/plugins-slate';
+
+import PageLayout from '../../components/PageLayout';
+
+const customContentPluginWithSpecialForm: CellPlugin<{
+  firstName: string;
+  lastName: string;
+  street: string;
+  zip: string;
+  city: string;
+  country: string;
+  age: number;
+}> = {
+  Renderer: ({ data }) => (
+    <div>
+      <h3>Name</h3>
+      <p>Firstname: {data.firstName}</p>
+      <p>Lastname: {data.lastName}</p>
+      <p>Age: {data.age}</p>
+      <h3>Adress</h3>
+      <p>{data.street}</p>
+      <p>{data.lastName}</p>
+      <p>Age: {data.age}</p>
+    </div>
+  ),
+  id: 'custom-content-plugin-with-custom-layout',
+  title: 'Custom content plugin',
+  description: 'Some custom content plugin with multiple controls',
+  version: 1,
+  controls: {
+    type: 'autoform',
+    schema: {
+      properties: {
+        firstName: { type: 'string' },
+        lastName: { type: 'string' },
+        street: { type: 'string' },
+        zip: { type: 'string' },
+        city: { type: 'string' },
+        country: { type: 'string' },
+
+        age: {
+          title: 'Age in years',
+          type: 'integer',
+          minimum: 0,
+        },
+      },
+      required: [],
+    },
+    Content: () => (
+      <div style={{ display: 'flex' }}>
+        <div style={{ flex: 1, marginRight: 20 }}>
+          <p>Personal information:</p>
+          <AutoFields fields={['firstName', 'lastName', 'age']} />
+        </div>
+        <div style={{ flex: 1 }}>
+          <p>Adress:</p>
+          <AutoFields omitFields={['firstName', 'lastName', 'age']} />
+        </div>
+      </div>
+    ),
+  },
+};
+
+const cellPlugins = [slate(), customContentPluginWithSpecialForm];
+
+const INITIAL_VALUE = createValue(
+  {
+    rows: [
+      [
+        {
+          plugin: customContentPluginWithSpecialForm,
+        },
+      ],
+    ],
+  },
+  {
+    cellPlugins,
+    lang: 'default',
+  }
+);
+export default function CustomFormLayout() {
+  const [value, setValue] = useState<Value>(INITIAL_VALUE);
+
+  return (
+    <PageLayout>
+      <Editor cellPlugins={cellPlugins} value={value} onChange={setValue} />
+    </PageLayout>
+  );
+}

--- a/packages/editor/src/core/types/plugins.ts
+++ b/packages/editor/src/core/types/plugins.ts
@@ -72,6 +72,12 @@ export type CellPluginRenderer<DataT> = React.ComponentType<
 export type CellPluginCustomControlsComonent<DataT> = React.ComponentType<
   CellPluginComponentProps<DataT>
 >;
+
+export type CellPluginAutoformControlsContent<DataT> = React.ComponentType<{
+  data: DataT;
+  columnCount?: number;
+}>;
+
 /**
  * controls where you can provide a custom component to render the controls.
  */
@@ -96,6 +102,12 @@ export type AutoformControlsDef<DataT> = {
    * autoform type automatically generates a form for you.
    */
   type: 'autoform';
+
+  /**
+   * You can customize the form content by passing a custom component. It will be rendered inside the Autoform.
+   * This can be used to adjust the layout of the form using `<Autofield />`
+   */
+  Content?: CellPluginAutoformControlsContent<DataT>;
 };
 
 export type SubControlsDef<T> = {

--- a/packages/editor/src/ui/AutoformControls/index.tsx
+++ b/packages/editor/src/ui/AutoformControls/index.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment, useEffect, useMemo } from 'react';
 import type JSONSchemaBridge from 'uniforms-bridge-json-schema';
+import type { AutoFieldProps, AutoFieldsProps } from 'uniforms-material';
 import { useIsSmallScreen } from '../../core/components/hooks';
 import lazyLoad from '../../core/helper/lazyLoad';
 
@@ -13,14 +14,15 @@ import makeUniformsSchema from './makeUniformsSchema';
 export const AutoForm = lazyLoad(() =>
   import('uniforms-material').then((c) => c.AutoForm)
 );
+export const AutoField = lazyLoad(() =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  import('uniforms-material').then((c) => c.AutoField as any)
+) as React.FC<AutoFieldProps>;
+
 export const AutoFields = lazyLoad(() =>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   import('uniforms-material').then((c) => c.AutoFields as any)
-) as React.FC<{
-  element?: React.ReactNode;
-  fields?: string[];
-  omitFields?: string[];
-}>;
+) as React.FC<AutoFieldsProps>;
 const getDefaultValue = function (
   bridge: JSONSchemaBridge
 ): { [key: string]: unknown } {
@@ -39,6 +41,7 @@ export function AutoformControls<T extends Record<string, unknown> | unknown>({
   data,
   schema,
   columnCount = 2,
+  Content,
 }: Props<T>) {
   const bridge = useMemo(() => makeUniformsSchema<T>(schema as JsonSchema<T>), [
     schema,
@@ -53,15 +56,19 @@ export function AutoformControls<T extends Record<string, unknown> | unknown>({
   const isSmall = useIsSmallScreen();
   return (
     <AutoForm model={data} autosave={true} schema={bridge} onSubmit={onChange}>
-      <div
-        style={{
-          columnCount: isSmall ? 1 : columnCount,
-          columnRule: '1px solid #E0E0E0',
-          columnGap: 48,
-        }}
-      >
-        <AutoFields element={Fragment} />
-      </div>
+      {Content ? (
+        <Content data={data} columnCount={columnCount} />
+      ) : (
+        <div
+          style={{
+            columnCount: isSmall ? 1 : columnCount,
+            columnRule: '1px solid #E0E0E0',
+            columnGap: 48,
+          }}
+        >
+          <AutoFields element={Fragment} />
+        </div>
+      )}
     </AutoForm>
   );
 }


### PR DESCRIPTION
feat(CellPlugin): autoform controls now allows custom layouts

you can now specify `Content`-property which takes a component that is rendered
in the uniform's autoform. Sou you can use `<Autofield name="fieldname" />`
to render single fields
or `<Autofields fields={["field1", "field2"]} />` to render multiple fields

