### PR TITLE
Fix: BottomToolbar stop propagation

### DIFF
--- a/packages/editor/src/core/components/Cell/index.tsx
+++ b/packages/editor/src/core/components/Cell/index.tsx
@@ -85,7 +85,8 @@ const Cell: React.FC<Props> = ({ nodeId, measureRef }) => {
   const onClick = useCallback(
     (e) => {
       if (hasPlugin && isEditMode) {
-        e.stopPropagation();
+        // Code bellow was causing the BottomToolbar to be unclickable with regards to document.addEventListener('click', ...)
+        // e.stopPropagation();
       }
       if (isInsertMode) {
         e.stopPropagation();


### PR DESCRIPTION
Signed-off-by: Peter Kottas <petokottas@gmail.com>
Removed extra stopPropagation on the cell in edit mode that's causing the BottomToolbar to mute clicks when listening for it via document.addEventListener 