### PR TITLE
Fix: Cell didn't focus after duplicate

### DIFF
--- a/packages/editor/src/core/actions/cell/insert.ts
+++ b/packages/editor/src/core/actions/cell/insert.ts
@@ -48,6 +48,7 @@ export interface InsertAction extends Action {
 
 export type PluginsAndLang = {
   lang: string;
+  focusAfter?: boolean;
 } & Pick<Options, 'cellPlugins'>;
 
 export const createRow = (
@@ -167,10 +168,10 @@ const insert = <T extends InsertType>(type: T) => (options: PluginsAndLang) => (
   return (dispatch) => {
     dispatch(insertAction);
     // FIXME: checking if an item is new or just moved around is a bit awkward
-
+    // FIXME: this doesn't work when duplicating, I've added an option to focus after insert
     const isNew = !partialCell.id;
 
-    if (isNew) {
+    if (options.focusAfter) {
       dispatch(editMode());
       setTimeout(() => {
         dispatch(focusCell(insertAction.ids.item, true));

--- a/packages/editor/src/core/components/hooks/nodeActions.ts
+++ b/packages/editor/src/core/components/hooks/nodeActions.ts
@@ -119,7 +119,12 @@ export const useDuplicateCell = (id: string) => {
   const cellPlugins = useAllCellPluginsForNode(parentCellId);
 
   return useCallback(
-    () => dispatch(duplicateCell({ cellPlugins, lang })(editor.getNode(id))),
+    () =>
+      dispatch(
+        duplicateCell({ cellPlugins, lang, focusAfter: true })(
+          editor.getNode(id)
+        )
+      ),
     [dispatch, cellPlugins, lang, id]
   );
 };


### PR DESCRIPTION
At some point, the "focus after duplicate" functionality got broken. I suspect it's because now we recreate all ids so the check that was previously there for moving things doesn't work (the id is already created once we go to that check). I've added a new option that defaults to current (broken) functionality.