### PR TITLE
fix: insert new does not focus cell

### DIFF
--- a/packages/editor/src/core/components/hooks/nodeActions.ts
+++ b/packages/editor/src/core/components/hooks/nodeActions.ts
@@ -219,6 +219,7 @@ export const useInsertNew = (parentCellId?: string) => {
         action({
           cellPlugins,
           lang,
+          focusAfter: true,
         })(partialCell, { id: parentCellId })
       );
     },


### PR DESCRIPTION
fixes https://github.com/react-page/react-page/issues/1012


@PeterKottas that uses your new focusAfter option
