### PR TITLE
fix: drag & drop in nested plugins behave wrong

### DIFF
--- a/packages/editor/src/core/components/Cell/Droppable/index.tsx
+++ b/packages/editor/src/core/components/Cell/Droppable/index.tsx
@@ -38,11 +38,14 @@ export const useCellDrop = (nodeId: string) => {
         }
       : null
   );
-  const checkIfAllowed = useCellIsAllowedHere(nodeId);
+
+  const targetParentNodeId = hoverTarget?.ancestorIds?.[0];
+
+  const checkIfAllowed = useCellIsAllowedHere(targetParentNodeId);
   const plugin = usePluginOfCell(nodeId);
   const options = useOptions();
   const hoverActions = useHoverActions();
-  const dropActions = useDropActions(nodeId);
+  const dropActions = useDropActions(targetParentNodeId);
   const isHoveringOverThis = useSelector(
     (state: RootState) => state.reactPage.hover?.nodeId === nodeId
   );


### PR DESCRIPTION
fixes https://github.com/react-page/react-page/issues/1000


the bug arises from a confusion in the code:

if a cell is dropped, we have the `hoverTarget`, which is NOT the parent row or cell, but the new sibling.

So if you want to find out what is allowed next to that sibling, we have to look at the parent of the sibling, but the previous implementation used that node instead. If that node defined some custom cellplugins, this would lead to the bug described