### PR TITLE
feat(slate): slate uses now a custom static renderer in readonly mode

### DIFF
--- a/examples/pages/readonly-bare.tsx
+++ b/examples/pages/readonly-bare.tsx
@@ -1,0 +1,8 @@
+import Editor from '@react-page/editor';
+import React from 'react';
+import { cellPlugins } from '../plugins/cellPlugins';
+import { demo } from '../sampleContents/demo';
+
+export default function ReadOnlyBare() {
+  return <Editor cellPlugins={cellPlugins} value={demo} lang="en" readOnly />;
+}

--- a/packages/editor/src/core/types/plugins.ts
+++ b/packages/editor/src/core/types/plugins.ts
@@ -190,6 +190,12 @@ export type CellPlugin<DataT = unknown, DataSerializedT = DataT> = {
   Provider?: React.ComponentType<CellPluginComponentProps<DataT>>;
 
   /**
+   * by default, Provider is also rendered in readOnly. You can disable that by setting disableProviderInReadOnly to true
+   *
+   */
+  disableProviderInReadOnly?: boolean;
+
+  /**
    * the icon to show for this plugin
    */
   icon?: React.ReactNode;

--- a/packages/editor/src/renderer/HTMLRenderer.tsx
+++ b/packages/editor/src/renderer/HTMLRenderer.tsx
@@ -87,7 +87,10 @@ const HTMLCell: React.FC<
     const { Renderer } = plugin;
 
     const cellStyle = getCellStyle(plugin, data);
-    const Provider = plugin.Provider ?? NoopProvider;
+    const Provider =
+      plugin.Provider && !plugin.disableProviderInReadOnly
+        ? plugin.Provider
+        : NoopProvider;
 
     let pluginCellSpacing = getPluginCellSpacing(plugin, data);
     if (typeof pluginCellSpacing === 'undefined' || pluginCellSpacing == null) {

--- a/packages/plugins/content/slate/package.json
+++ b/packages/plugins/content/slate/package.json
@@ -43,7 +43,8 @@
     "slate": "^0.63.0",
     "slate-react": "^0.65.0",
     "slate-hyperscript": "^0.62.0",
-    "@emotion/is-prop-valid": "^0.8.8"
+    "@emotion/is-prop-valid": "^0.8.8",
+    "slate-react-presentation": "^0.1.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugins/content/slate/src/components/ReadOnlySlate.tsx
+++ b/packages/plugins/content/slate/src/components/ReadOnlySlate.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { SlateReactPresentation } from 'slate-react-presentation';
+import type { SlateProps } from '../types/component';
+import { useRenderElement, useRenderLeave } from './renderHooks';
+
+const ReadOnlySlate = (props: SlateProps) => {
+  const { plugins, defaultPluginType } = props;
+
+  const renderElement = useRenderElement(
+    {
+      plugins,
+      defaultPluginType,
+    },
+    []
+  );
+  const renderLeaf = useRenderLeave({ plugins }, []);
+  // the div around is required to be consistent in styling with the default editor
+  return (
+    <div>
+      <SlateReactPresentation
+        renderElement={renderElement}
+        renderLeaf={renderLeaf}
+        value={props.data.slate}
+      />
+    </div>
+  );
+};
+
+export default React.memo(ReadOnlySlate);

--- a/packages/plugins/content/slate/src/components/renderHooks.tsx
+++ b/packages/plugins/content/slate/src/components/renderHooks.tsx
@@ -31,15 +31,19 @@ type Injections = {
   useSelected: () => boolean;
   useFocused: () => boolean;
 };
+const STATIC_INJECTIONS = {
+  useFocused: () => false,
+  useSelected: () => false,
+};
 export const useRenderElement = (
   {
     plugins,
     defaultPluginType,
-    injections,
+    injections = STATIC_INJECTIONS,
   }: {
     plugins: SlatePlugin[];
     defaultPluginType: string;
-    injections: Injections;
+    injections?: Injections;
   },
   deps: DependencyList
 ) => {
@@ -96,7 +100,10 @@ export const useRenderElement = (
 };
 
 export const useRenderLeave = (
-  { plugins, injections }: { plugins: SlatePlugin[]; injections: Injections },
+  {
+    plugins,
+    injections = STATIC_INJECTIONS,
+  }: { plugins: SlatePlugin[]; injections?: Injections },
   deps: DependencyList
 ) => {
   const markPlugins = useComponentMarkPlugins({ plugins }, deps);

--- a/packages/plugins/content/slate/yarn.lock
+++ b/packages/plugins/content/slate/yarn.lock
@@ -205,6 +205,11 @@ slate-hyperscript@^0.62.0:
   dependencies:
     is-plain-object "^3.0.0"
 
+slate-react-presentation@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/slate-react-presentation/-/slate-react-presentation-0.1.0.tgz#6fd533b8f489e8f66aa5955173c928c7082862e0"
+  integrity sha512-+qD7dgx+J/h+IXykF2+nTolwMV50qtz8HwrRJMmCOaw5bNYcB3uLRkChZHTFHfgLVlqsl6FaNy9+LEtMISJVxQ==
+
 slate-react@^0.65.0:
   version "0.65.0"
   resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.65.0.tgz#58e19f42f1bda726626c5b75a677bb783fc13853"


### PR DESCRIPTION
this reduces bundle size (about 25kb gzipped) and probably render time (not measured yet) and unclutters the dom a bit.

it also introduces a new property `disableProviderInReadOnly` that will not render the provider in readonly mode.
As a matter of fact, slate is the only plugin we provide that uses a provider. It was necessary to also render the Provider in readonly mode,
but that is no longer true. We might deprecate that in the futur or make disableProviderInReadOnly the default.

BREAKING CHANGE: dom in readonly mode is slightly different

the resulting dom in readonly mode differ a bit from previous versions. (less elements)
This had no impact at all in the example project, but depending on your application
you might need to adjust styling. That is why this is released as a breaking change.


this will be released first on beta as i need to test it on different apps first