### PR TITLE
feat(sidebar): can add custom options in sidebar

### DIFF
--- a/packages/editor/src/core/defaultOptions.ts
+++ b/packages/editor/src/core/defaultOptions.ts
@@ -13,6 +13,12 @@ export const DEFAULT_OPTIONS: Required<Options> = {
   uiTranslator: null,
   zoomEnabled: true,
   zoomFactors: [1, 0.75, 0.5, 0.25],
+  undoRedoEnabled: true,
+  editEnabled: true,
+  insertEnabled: true,
+  layoutEnabled: true,
+  resizeEnabled: true,
+  previewEnabled: true,
 
   dndBackend: HTML5Backend,
   blurGateDefaultMode: DISPLAY_MODE_EDIT,

--- a/packages/editor/src/core/defaultOptions.ts
+++ b/packages/editor/src/core/defaultOptions.ts
@@ -22,6 +22,8 @@ export const DEFAULT_OPTIONS: Required<Options> = {
   hideEditorSidebar: false,
   showMoveButtonsInBottomToolbar: true,
   showMoveButtonsInLayoutMode: true,
+
+  customOptions: [],
 };
 
 export const DEFAULT_RENDER_OPTIONS: Required<RenderOptions> = {

--- a/packages/editor/src/core/types/options.ts
+++ b/packages/editor/src/core/types/options.ts
@@ -85,4 +85,6 @@ export type Options = {
    *
    */
   hideEditorSidebar?: boolean;
+
+  customOptions?: React.ComponentType[];
 };

--- a/packages/editor/src/core/types/options.ts
+++ b/packages/editor/src/core/types/options.ts
@@ -40,6 +40,36 @@ export type Options = {
   zoomEnabled?: boolean;
 
   /**
+   * enable undo redo option
+   */
+  undoRedoEnabled?: boolean;
+
+  /**
+   * enable edit option
+   */
+  editEnabled?: boolean;
+
+  /**
+   * enable insert option
+   */
+  insertEnabled?: boolean;
+
+  /**
+   * enable layout option
+   */
+  layoutEnabled?: boolean;
+
+  /**
+   * enable resize option
+   */
+  resizeEnabled?: boolean;
+
+  /**
+   * enable preview option
+   */
+  previewEnabled?: boolean;
+
+  /**
    * set the zoom factors. Defaults to [1, 0.75, 0.5, 0.25]
    */
   zoomFactors?: number[];

--- a/packages/editor/src/ui/Sidebar/index.tsx
+++ b/packages/editor/src/ui/Sidebar/index.tsx
@@ -37,6 +37,12 @@ export const Sidebar: React.SFC<{
 }> = ({ stickyNess }) => {
   const { t } = useUiTranslator();
   const zoomEnabled = useOption('zoomEnabled');
+  const undoRedoEnabled = useOption('undoRedoEnabled');
+  const editEnabled = useOption('editEnabled');
+  const insertEnabled = useOption('insertEnabled');
+  const layoutEnabled = useOption('layoutEnabled');
+  const resizeEnabled = useOption('resizeEnabled');
+  const previewEnabled = useOption('previewEnabled');
   const defaultLabels = {
     edit: 'Edit blocks',
     insert: 'Add blocks',
@@ -49,15 +55,27 @@ export const Sidebar: React.SFC<{
 
   const actions = [
     // eslint-disable-next-line react/jsx-key
-    { action: <UndoRedo labelRedo="redo" labelUndo="undo" /> },
+    undoRedoEnabled
+      ? { action: <UndoRedo labelRedo="redo" labelUndo="undo" /> }
+      : null,
     zoomEnabled
       ? { action: <Zoom labelZoomIn="zoom in" labelZoomOut="zoom out" /> }
       : null,
-    { action: <ToggleEdit label={t(defaultLabels.edit)} /> },
-    { action: <ToggleInsert label={t(defaultLabels.insert)} /> },
-    { action: <ToggleLayout label={t(defaultLabels.layout)} /> },
-    { action: <ToggleResize label={t(defaultLabels.resize)} /> },
-    { action: <TogglePreview label={t(defaultLabels.preview)} /> },
+    editEnabled
+      ? { action: <ToggleEdit label={t(defaultLabels.edit)} /> }
+      : null,
+    insertEnabled
+      ? { action: <ToggleInsert label={t(defaultLabels.insert)} /> }
+      : null,
+    layoutEnabled
+      ? { action: <ToggleLayout label={t(defaultLabels.layout)} /> }
+      : null,
+    resizeEnabled
+      ? { action: <ToggleResize label={t(defaultLabels.resize)} /> }
+      : null,
+    previewEnabled
+      ? { action: <TogglePreview label={t(defaultLabels.preview)} /> }
+      : null,
     ...customOptions.map((customOption) => ({ action: customOption })),
   ].filter(Boolean);
   return (

--- a/packages/editor/src/ui/Sidebar/index.tsx
+++ b/packages/editor/src/ui/Sidebar/index.tsx
@@ -45,7 +45,7 @@ export const Sidebar: React.SFC<{
     preview: 'Preview page',
   };
 
-  const customOptions = useOption('customOptions') ?? [];
+  const customOptions = useOption('customOptions');
 
   const actions = [
     // eslint-disable-next-line react/jsx-key

--- a/packages/editor/src/ui/Sidebar/index.tsx
+++ b/packages/editor/src/ui/Sidebar/index.tsx
@@ -44,6 +44,9 @@ export const Sidebar: React.SFC<{
     resize: 'Resize blocks',
     preview: 'Preview page',
   };
+
+  const customOptions = useOption('customOptions') ?? [];
+
   const actions = [
     // eslint-disable-next-line react/jsx-key
     { action: <UndoRedo labelRedo="redo" labelUndo="undo" /> },
@@ -55,6 +58,7 @@ export const Sidebar: React.SFC<{
     { action: <ToggleLayout label={t(defaultLabels.layout)} /> },
     { action: <ToggleResize label={t(defaultLabels.resize)} /> },
     { action: <TogglePreview label={t(defaultLabels.preview)} /> },
+    ...customOptions.map((customOption) => ({ action: customOption })),
   ].filter(Boolean);
   return (
     <div


### PR DESCRIPTION
## Proposed changes

We can add custom option in the sidebar.

The purpose in my case is to add a save button

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

I didn't add documentation yet, I'm waiting to have an agreement of my feature before adding it