### PR TITLE
feat: new sidebar position options

### DIFF
--- a/examples/pages/examples/sidebarPosition.tsx
+++ b/examples/pages/examples/sidebarPosition.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+
+// The editor core
+import type { Options, Value } from '@react-page/editor';
+import Editor from '@react-page/editor';
+
+// import the main css, uncomment this: (this is commented in the example because of https://github.com/vercel/next.js/issues/19717)
+// import '@react-page/editor/lib/index.css';
+
+// The rich text area plugin
+import slate from '@react-page/plugins-slate';
+// image
+import image from '@react-page/plugins-image';
+import PageLayout from '../../components/PageLayout';
+
+// Stylesheets for the rich text area plugin
+// uncomment this
+//import '@react-page/plugins-slate/lib/index.css';
+
+// Stylesheets for the imagea plugin
+//import '@react-page/plugins-image/lib/index.css';
+
+// Define which plugins we want to use.
+const cellPlugins = [slate(), image];
+
+export default function SimpleExample() {
+  const [value, setValue] = useState<Value>(null);
+
+  const [sidebarPosition, setSidebarPosition] =
+    useState<Options['sidebarPosition']>('rightAbsolute');
+
+  return (
+    <PageLayout>
+      <select
+        onChange={(e) =>
+          setSidebarPosition(e.target.value as Options['sidebarPosition'])
+        }
+      >
+        <option>rightAbsolute</option>
+        <option>rightRelative</option>
+
+        <option>leftRelative</option>
+        <option value="leftAbsolute">
+          leftAbsolute (currently buggy and interfers with other ui elements)
+        </option>
+      </select>
+      <Editor
+        cellPlugins={cellPlugins}
+        value={value}
+        onChange={setValue}
+        sidebarPosition={sidebarPosition}
+      />
+    </PageLayout>
+  );
+}

--- a/packages/editor/src/core/defaultOptions.ts
+++ b/packages/editor/src/core/defaultOptions.ts
@@ -28,6 +28,7 @@ export const DEFAULT_OPTIONS: Required<Options> = {
   hideEditorSidebar: false,
   showMoveButtonsInBottomToolbar: true,
   showMoveButtonsInLayoutMode: true,
+  sidebarPosition: 'rightAbsolute',
 
   customOptions: [],
 };

--- a/packages/editor/src/core/types/options.ts
+++ b/packages/editor/src/core/types/options.ts
@@ -112,7 +112,21 @@ export type Options = {
   middleware?: Middleware[];
 
   /**
+   * set the position of the sidebar. Possible values:
+   * - rightAbsolute (default): position it right on the screen absolutly
+   * - rightRelative: immediatly right of the content
+   * - leftRelative: immediatly left of the content
    *
+   * Possible, but does not yet work proplery:
+   * - leftAbsolute: left absolute on the screen
+   */
+  sidebarPosition?:
+    | 'rightAbsolute'
+    | 'rightRelative'
+    | 'leftAbsolute'
+    | 'leftRelative';
+  /**
+   * hide the editor sidebar
    */
   hideEditorSidebar?: boolean;
 

--- a/packages/editor/src/ui/EditorUI/index.tsx
+++ b/packages/editor/src/ui/EditorUI/index.tsx
@@ -14,6 +14,7 @@ export default React.memo(
       shouldStickToTop: false,
       shouldStickToBottom: false,
       rightOffset: 0,
+      rightOffsetFixed: 0,
     },
   }: {
     stickyNess?: StickyNess;

--- a/packages/editor/src/ui/Sidebar/index.tsx
+++ b/packages/editor/src/ui/Sidebar/index.tsx
@@ -15,6 +15,7 @@ const getStickyNessstyle = (stickyness?: StickyNess): React.CSSProperties => {
   ) {
     return {
       position: 'fixed',
+      right: stickyness.rightOffsetFixed || 0,
     };
   }
 
@@ -30,6 +31,7 @@ export type StickyNess = {
   shouldStickToTop: boolean;
   shouldStickToBottom: boolean;
   rightOffset: number;
+  rightOffsetFixed: number;
   stickyElRef?: React.Ref<HTMLDivElement>;
 };
 export const Sidebar: React.SFC<{


### PR DESCRIPTION
feat: new sidebar position options

- rightAbsolute: the default, fixed to the right of the screen
- rightRelative: immediatly right to the content
- leftRelative: immediatly left to the content

possible, but currently not implemented fully:

- leftAbsolute: left on the screen