### PR TITLE
fix(image-plugin): fix image plugin open in new window checkbox state

### DIFF
--- a/packages/plugins/content/image/src/Controls/ImageControls.tsx
+++ b/packages/plugins/content/image/src/Controls/ImageControls.tsx
@@ -65,7 +65,7 @@ const ImageControls: ImageControlType = (props) => {
       <FormControlLabel
         control={
           <Checkbox
-            value={props.data.openInNewWindow ?? false}
+            checked={props.data.openInNewWindow ?? false}
             onChange={(e) =>
               props.onChange({
                 openInNewWindow: e.target.checked,


### PR DESCRIPTION
change property of open in new window checkbox element of the image
plugin from 'value' to 'checked' so that it displays the correct state
of the openInNewWindow property

fixes issue #1140  Image plugin: "Open link in new window checkbox" is always unchecked

<!--- Provide a general summary of your changes in the Title above -->

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Change property of the checkbox element 'open in new window' in image plugin
following the controlled checkbox documentation of Material UI: https://v4.mui.com/api/checkbox/

## Types of changes

<!-- What types of changes does your code introduce to react-page? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Closing issues

<!-- Put `Closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
`Closes #1140`

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
