### PR TITLE
fix(Autoform):Disable actions if schema null

### DIFF
--- a/packages/plugins/content/slate/src/pluginFactories/components/UniformsControls.tsx
+++ b/packages/plugins/content/slate/src/pluginFactories/components/UniformsControls.tsx
@@ -91,6 +91,7 @@ function Controls<T extends Data>(
           </AutoForm>
         ) : null}
       </DialogContent>
+       {hasSchema ? (
       <DialogActions>
         <Button
           variant="text"
@@ -111,6 +112,7 @@ function Controls<T extends Data>(
           <DoneIcon style={{ marginLeft: 10 }} />
         </Button>
       </DialogActions>
+        ) : null}
     </Dialog>
   );
 }


### PR DESCRIPTION
Uniform- auto form actions should not be displayed when schema is null.
Refer #1175

Autoforms in plugins-slate shows autoform with cancel and ok button.


## Proposed changes

if schema is null auto-form should not be rendered

## Types of changes

plugins-slate plugins wont render a auto from if schema of uniform control is null

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Closing issues

<!-- Put `Closes #1175` in your comment to auto-close the issue that your PR fixes (if such). -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
