### PR TITLE
feat!: replace @loadable/components with React.lazy

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@semantic-release/exec": "semantic-release/exec",
     "@testing-library/react-hooks": "^3.4.2",
     "@types/jest": "^26.0.19",
-    "@types/loadable__component": "^5.13.3",
     "@types/react": "^17.0.24",
     "@types/react-dom": "^17.0.9",
     "@types/react-redux": "^7.1.15",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@mui/material": "^5.8.1",
     "@mui/icons-material": "^5.8.0",
-    "@loadable/component": "^5.15.0",
     "@welldone-software/why-did-you-render": "^6.0.5",
     "ajv": "^7.1.1",
     "classnames": "^2.3.1",

--- a/packages/editor/src/core/helper/lazyLoad/index.tsx
+++ b/packages/editor/src/core/helper/lazyLoad/index.tsx
@@ -1,3 +1,0 @@
-import lazyLoad from '@loadable/component';
-
-export default lazyLoad;

--- a/packages/editor/src/editor/Editor.tsx
+++ b/packages/editor/src/editor/Editor.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useState } from 'react';
-import lazyLoad from '../core/helper/lazyLoad';
+import React, { lazy, Suspense, useEffect, useState } from 'react';
 import type {
   Callbacks,
   Options,
@@ -8,7 +7,7 @@ import type {
 } from '../core/types';
 import { HTMLRenderer } from '../renderer/HTMLRenderer';
 
-const EditableEditor = lazyLoad(() => import('./EditableEditor'));
+const EditableEditor = lazy(() => import('./EditableEditor'));
 
 export type EditorProps = {
   /**
@@ -69,7 +68,7 @@ const Editor: React.FC<EditorProps> = ({
       cellSpacing={cellSpacing}
     />
   ) : (
-    <EditableEditor
+    <Suspense
       fallback={
         <HTMLRenderer
           value={value}
@@ -77,14 +76,16 @@ const Editor: React.FC<EditorProps> = ({
           lang={lang}
           cellSpacing={cellSpacing}
         />
-      }
-      value={value}
-      lang={lang}
-      options={options}
-      renderOptions={renderOptions}
-      callbacks={callbacks}
-      children={children}
-    />
+      }>
+      <EditableEditor
+        value={value}
+        lang={lang}
+        options={options}
+        renderOptions={renderOptions}
+        callbacks={callbacks}
+        children={children}
+      />
+    </Suspense>
   );
 };
 

--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -3,7 +3,6 @@ export * from './core/types';
 export * from './core/components/hooks';
 export * from './ui';
 
-import lazyLoad from './core/helper/lazyLoad';
 import { Migration } from './core/migrations/Migration';
 
 import Editor, { EditorProps } from './editor/Editor';
@@ -16,7 +15,6 @@ import { createValue } from './core/utils/createValue';
 import { objIsNode } from './core/utils/objIsNode';
 import { getTextContents } from './core/utils/getTextContents';
 export { objIsNode };
-export { lazyLoad };
 export { EditorProps };
 export { Migration };
 export { makeUniformsSchema };

--- a/packages/editor/src/ui/AutoformControls/AutoForm.tsx
+++ b/packages/editor/src/ui/AutoformControls/AutoForm.tsx
@@ -13,7 +13,7 @@ type OptionalFields =
   | 'validate'
   | 'autosave';
 type Props = Omit<AutoFormProps<unknown>, OptionalFields> &
-  Partial<AutoFormProps<unknown>>;
+  Partial<AutoFormProps<unknown>> & { children: React.ReactNode; };
 export default forwardRef((props: Props, ref) => (
   <AutofieldContextProvider>
     <AutoForm {...props} ref={ref as any} />

--- a/packages/editor/src/ui/AutoformControls/index.tsx
+++ b/packages/editor/src/ui/AutoformControls/index.tsx
@@ -1,7 +1,6 @@
-import React, { Fragment, useEffect, useMemo } from 'react';
+import React, { Fragment, lazy, Suspense, useEffect, useMemo } from 'react';
 import type JSONSchemaBridge from 'uniforms-bridge-json-schema';
 import { useIsSmallScreen } from '../../core/components/hooks';
-import lazyLoad from '../../core/helper/lazyLoad';
 
 import type {
   AutoformControlsDef,
@@ -11,9 +10,9 @@ import type {
 } from '../../core/types';
 import makeUniformsSchema from './makeUniformsSchema';
 
-export const AutoForm = lazyLoad(() => import('./AutoForm'));
-export const AutoField = lazyLoad(() => import('./AutoField'));
-export const AutoFields = lazyLoad(() => import('./AutoFields'));
+export const AutoForm = lazy(() => import('./AutoForm'));
+export const AutoField = lazy(() => import('./AutoField'));
+export const AutoFields = lazy(() => import('./AutoFields'));
 
 const getDefaultValue = function (bridge: JSONSchemaBridge): {
   [key: string]: unknown;

--- a/packages/editor/src/ui/ColorPicker/index.tsx
+++ b/packages/editor/src/ui/ColorPicker/index.tsx
@@ -1,5 +1,6 @@
-import lazyLoad from '../../core/helper/lazyLoad';
-export const ColorPicker = lazyLoad(() => import('./ColorPicker'));
-export const ColorPickerField = lazyLoad(() => import('./ColorPickerField'));
+import { lazy } from 'react';
+
+export const ColorPicker = lazy(() => import('./ColorPicker'));
+export const ColorPickerField = lazy(() => import('./ColorPickerField'));
 export * from './colorToString';
 export * from './types';

--- a/packages/editor/src/ui/ImageUpload/index.tsx
+++ b/packages/editor/src/ui/ImageUpload/index.tsx
@@ -1,5 +1,5 @@
-import lazyLoad from '../../core/helper/lazyLoad';
+import { lazy } from 'react';
 
 export * from './types';
 
-export const ImageUpload = lazyLoad(() => import('./ImageUpload'));
+export const ImageUpload = lazy(() => import('./ImageUpload'));

--- a/packages/plugins/content/divider/src/createPlugin.tsx
+++ b/packages/plugins/content/divider/src/createPlugin.tsx
@@ -1,12 +1,11 @@
 import type { CellPlugin } from '@react-page/editor';
-import { lazyLoad } from '@react-page/editor';
-import React from 'react';
+import React, { lazy } from 'react';
 import { defaultSettings } from './default/settings';
 import DividerHtmlRenderer from './Renderer/DividerHtmlRenderer';
 
 import type { DividerSettings } from './types/settings';
 
-const Remove = lazyLoad(() => import('@mui/icons-material/Remove'));
+const Remove = lazy(() => import('@mui/icons-material/Remove'));
 
 const createPlugin: (settings: DividerSettings) => CellPlugin = (settings) => {
   const mergedSettings = { ...defaultSettings, ...settings };

--- a/packages/plugins/content/html5-video/src/default/settings.tsx
+++ b/packages/plugins/content/html5-video/src/default/settings.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
+import React, { lazy } from 'react';
 import type { Html5VideoSettings } from '../types/settings';
-import { lazyLoad } from '@react-page/editor';
 
-const PlayArrow = lazyLoad(() => import('@mui/icons-material/PlayArrow'));
+const PlayArrow = lazy(() => import('@mui/icons-material/PlayArrow'));
 
 export const defaultTranslations = {
   pluginName: 'HTML 5 Video',

--- a/packages/plugins/content/image/src/Renderer/ImageHtmlRenderer.tsx
+++ b/packages/plugins/content/image/src/Renderer/ImageHtmlRenderer.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
+import React, { lazy } from 'react';
 
 import { iconStyle } from './../common/styles';
 import type { CellPluginComponentProps } from '@react-page/editor';
-import { lazyLoad } from '@react-page/editor';
 import type { ImageState } from '../types/state';
 
-const ImageIcon = lazyLoad(() => import('@mui/icons-material/Landscape'));
+const ImageIcon = lazy(() => import('@mui/icons-material/Landscape'));
 
 const ImageHtmlRenderer: React.FC<CellPluginComponentProps<ImageState>> = (
   props

--- a/packages/plugins/content/image/src/default/settings.tsx
+++ b/packages/plugins/content/image/src/default/settings.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
+
 import type { ImageSettings } from '../types/settings';
-import { lazyLoad } from '@react-page/editor';
-const Panorama = lazyLoad(() => import('@mui/icons-material/Panorama'));
+const Panorama = lazy(() => import('@mui/icons-material/Panorama'));
 
 export const defaultTranslations = {
   pluginName: 'Image',

--- a/packages/plugins/content/image/src/index.tsx
+++ b/packages/plugins/content/image/src/index.tsx
@@ -1,20 +1,22 @@
+import { lazy } from 'react';
+
 import type { CellPlugin } from '@react-page/editor';
-import { lazyLoad, ImageUploadType } from '@react-page/editor';
+import { ImageUploadType } from '@react-page/editor';
 import createPlugin from './createPlugin';
 import ImageHtmlRenderer from './Renderer/ImageHtmlRenderer';
 import type { ImageSettings } from './types/settings';
 import type { ImageState } from './types/state';
 
-const ImageControls = lazyLoad(() => import('./Controls/ImageControls'));
+const ImageControls = lazy(() => import('./Controls/ImageControls'));
 
 const imagePlugin: (
   settings?: Partial<ImageSettings>
 ) => CellPlugin<ImageState> = (settings) =>
-  createPlugin({
-    Renderer: ImageHtmlRenderer,
-    Controls: ImageControls,
-    ...settings,
-  });
+    createPlugin({
+      Renderer: ImageHtmlRenderer,
+      Controls: ImageControls,
+      ...settings,
+    });
 
 const image = imagePlugin();
 export default image;

--- a/packages/plugins/content/slate/src/components/SlateEditor.tsx
+++ b/packages/plugins/content/slate/src/components/SlateEditor.tsx
@@ -1,9 +1,8 @@
 import {
-  lazyLoad,
   useAllFocusedNodeIds,
   useUiTranslator,
 } from '@react-page/editor';
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { Editable, useFocused, useSelected } from 'slate-react';
 import type { SlateProps } from '../types/component';
 import type { SlatePlugin } from '../types/SlatePlugin';
@@ -11,7 +10,7 @@ import { useDialogIsVisible } from './DialogVisibleProvider';
 import { useOnKeyDown } from './hotkeyHooks';
 import { useRenderElement, useRenderLeave } from './renderHooks';
 
-const HoverButtons = lazyLoad(() => import('./HoverButtons'));
+const HoverButtons = lazy(() => import('./HoverButtons'));
 
 const SlateEditable = React.memo(
   (props: {
@@ -53,10 +52,12 @@ const SlateEditor = (props: SlateProps) => {
   return (
     <>
       {!readOnly && focused && (
-        <HoverButtons
-          plugins={props.plugins}
-          translations={props.translations}
-        />
+        <Suspense fallback={<div>Loading...</div>}>
+          <HoverButtons
+            plugins={props.plugins}
+            translations={props.translations}
+          />
+        </Suspense>
       )}
       <SlateEditable
         placeholder={t(props.translations?.placeholder) ?? ''}

--- a/packages/plugins/content/slate/src/components/ToolbarButton.tsx
+++ b/packages/plugins/content/slate/src/components/ToolbarButton.tsx
@@ -1,9 +1,10 @@
-import { lazyLoad } from '@react-page/editor';
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
+
 import { ConditionalWrapper } from './ConditionalWrapper';
 import { useTheme } from '@mui/material';
-const IconButton = lazyLoad(() => import('@mui/material/IconButton'));
-const Tooltip = lazyLoad(() => import('@mui/material/Tooltip'));
+
+const IconButton = lazy(() => import('@mui/material/IconButton'));
+const Tooltip = lazy(() => import('@mui/material/Tooltip'));
 
 const ToolbarButton: React.SFC<{
   icon: JSX.Element | string;
@@ -19,27 +20,29 @@ const ToolbarButton: React.SFC<{
       condition={!disabled}
       wrapper={(children) => <Tooltip title={toolTip}>{children}</Tooltip>}
     >
-      <IconButton
-        onMouseDown={onClick}
-        style={{
-          transition: '0.3s',
-          ...(isActive
-            ? {
+      <Suspense fallback={<div>Loading...</div>}>
+        <IconButton
+          onMouseDown={onClick}
+          style={{
+            transition: '0.3s',
+            ...(isActive
+              ? {
                 transform: 'scale(1.15)',
                 color: theme.palette.primary.main,
               }
-            : disabled
-            ? { color: theme.palette.action.disabled }
-            : {
-                color: dark
-                  ? theme.palette.common.white
-                  : theme.palette.common.black,
-              }),
-        }}
-        disabled={disabled}
-      >
-        {icon}
-      </IconButton>
+              : disabled
+                ? { color: theme.palette.action.disabled }
+                : {
+                  color: dark
+                    ? theme.palette.common.white
+                    : theme.palette.common.black,
+                }),
+          }}
+          disabled={disabled}
+        >
+          {icon}
+        </IconButton>
+      </Suspense>
     </ConditionalWrapper>
   );
 };

--- a/packages/plugins/content/slate/src/components/renderHooks.tsx
+++ b/packages/plugins/content/slate/src/components/renderHooks.tsx
@@ -1,8 +1,7 @@
 import propisValid from '@emotion/is-prop-valid';
-import { lazyLoad } from '@react-page/editor';
 import isObject from 'lodash.isobject';
 import type { DependencyList } from 'react';
-import React, { useCallback } from 'react';
+import React, { lazy, Suspense, useCallback } from 'react';
 import type { RenderElementProps, RenderLeafProps } from 'slate-react';
 import type { SlatePlugin } from '../types/SlatePlugin';
 import type { SlatePluginDefinition } from '../types/slatePluginDefinitions';
@@ -13,7 +12,7 @@ import {
 } from './pluginHooks';
 
 // lazy load as it uses slate library. We don't want to bundle that in readonly mode
-const VoidEditableElement = lazyLoad(() => import('./VoidEditableElement'));
+const VoidEditableElement = lazy(() => import('./VoidEditableElement'));
 
 type Data = {
   [key: string]: unknown;
@@ -109,13 +108,15 @@ export const useRenderElement = (
 
         if (isVoid && !injections.readOnly) {
           return (
-            <VoidEditableElement
-              component={component}
-              element={element}
-              plugin={matchingPlugin as SlatePluginDefinition}
-            >
-              {children}
-            </VoidEditableElement>
+            <Suspense fallback={<div>Loading...</div>}>
+              <VoidEditableElement
+                component={component}
+                element={element}
+                plugin={matchingPlugin as SlatePluginDefinition}
+              >
+                {children}
+              </VoidEditableElement>
+            </Suspense>
           );
         }
 
@@ -132,7 +133,7 @@ export const useRenderLeave = (
     plugins,
     injections = STATIC_INJECTIONS,
     readOnly = false,
-  }: { plugins: SlatePlugin[]; injections?: Injections; readOnly?: boolean },
+  }: { plugins: SlatePlugin[]; injections?: Injections; readOnly?: boolean; },
 
   deps: DependencyList
 ) => {

--- a/packages/plugins/content/slate/src/plugins/alignment.tsx
+++ b/packages/plugins/content/slate/src/plugins/alignment.tsx
@@ -1,21 +1,21 @@
-import { lazyLoad } from '@react-page/editor';
-import React from 'react';
+import React, { lazy } from 'react';
+
 import createDataPlugin from '../pluginFactories/createDataPlugin';
 
-const AlignLeftIcon = lazyLoad(
+const AlignLeftIcon = lazy(
   () => import('@mui/icons-material/FormatAlignLeft')
 );
-const AlignCenterIcon = lazyLoad(
+const AlignCenterIcon = lazy(
   () => import('@mui/icons-material/FormatAlignCenter')
 );
-const AlignRightIcon = lazyLoad(
+const AlignRightIcon = lazy(
   () => import('@mui/icons-material/FormatAlignRight')
 );
-const AlignJustifyIcon = lazyLoad(
+const AlignJustifyIcon = lazy(
   () => import('@mui/icons-material/FormatAlignJustify')
 );
 
-const left = createDataPlugin<{ align: 'left' }>({
+const left = createDataPlugin<{ align: 'left'; }>({
   icon: <AlignLeftIcon />,
   label: 'Align Left',
   object: 'block',
@@ -25,7 +25,7 @@ const left = createDataPlugin<{ align: 'left' }>({
   getInitialData: () => ({ align: 'left' }),
 });
 
-const center = createDataPlugin<{ align: 'center' }>({
+const center = createDataPlugin<{ align: 'center'; }>({
   icon: <AlignCenterIcon />,
   label: 'Align Center',
   object: 'block',
@@ -35,7 +35,7 @@ const center = createDataPlugin<{ align: 'center' }>({
   getInitialData: () => ({ align: 'center' }),
 });
 
-const right = createDataPlugin<{ align: 'right' }>({
+const right = createDataPlugin<{ align: 'right'; }>({
   icon: <AlignRightIcon />,
   label: 'Align Right',
   object: 'block',
@@ -45,7 +45,7 @@ const right = createDataPlugin<{ align: 'right' }>({
   getInitialData: () => ({ align: 'right' }),
 });
 
-const justify = createDataPlugin<{ align: 'justify' }>({
+const justify = createDataPlugin<{ align: 'justify'; }>({
   icon: <AlignJustifyIcon />,
   label: 'Align Justify',
   object: 'block',

--- a/packages/plugins/content/slate/src/plugins/code/index.tsx
+++ b/packages/plugins/content/slate/src/plugins/code/index.tsx
@@ -1,8 +1,8 @@
-import { lazyLoad } from '@react-page/editor';
-import React from 'react';
+import React, { lazy } from 'react';
+
 import createComponentPlugin from '../../pluginFactories/createComponentPlugin';
 
-const Icon = lazyLoad(() => import('@mui/icons-material/Code'));
+const Icon = lazy(() => import('@mui/icons-material/Code'));
 
 const block = createComponentPlugin({
   type: 'CODE/CODE',

--- a/packages/plugins/content/slate/src/plugins/emphasize/em.tsx
+++ b/packages/plugins/content/slate/src/plugins/emphasize/em.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
+import React, { lazy } from 'react';
 
-import { lazyLoad } from '@react-page/editor';
 import createMarkPlugin from '../../pluginFactories/createMarkPlugin';
 
-const ItalicIcon = lazyLoad(() => import('@mui/icons-material/FormatItalic'));
+const ItalicIcon = lazy(() => import('@mui/icons-material/FormatItalic'));
 
 export default createMarkPlugin({
   type: 'EMPHASIZE/EM',

--- a/packages/plugins/content/slate/src/plugins/emphasize/strong.tsx
+++ b/packages/plugins/content/slate/src/plugins/emphasize/strong.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
+import React, { lazy } from 'react';
 
-import { lazyLoad } from '@react-page/editor';
 import createMarkPlugin from '../../pluginFactories/createMarkPlugin';
 
-const BoldIcon = lazyLoad(() => import('@mui/icons-material/FormatBold'));
+const BoldIcon = lazy(() => import('@mui/icons-material/FormatBold'));
 
 export default createMarkPlugin({
   type: 'EMPHASIZE/STRONG',

--- a/packages/plugins/content/slate/src/plugins/emphasize/underline.tsx
+++ b/packages/plugins/content/slate/src/plugins/emphasize/underline.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
+import React, { lazy } from 'react';
 
-import { lazyLoad } from '@react-page/editor';
 import createMarkPlugin from '../../pluginFactories/createMarkPlugin';
 
-const UnderlinedIcon = lazyLoad(
+const UnderlinedIcon = lazy(
   () => import('@mui/icons-material/FormatUnderlined')
 );
 

--- a/packages/plugins/content/slate/src/plugins/headings/index.tsx
+++ b/packages/plugins/content/slate/src/plugins/headings/index.tsx
@@ -1,12 +1,12 @@
 import createHeadingsPlugin from '../../pluginFactories/createHeadingsPlugin';
-import { lazyLoad } from '@react-page/editor';
-import React from 'react';
-const H1Icon = lazyLoad(() => import('@mui/icons-material/LooksOne'));
-const H2Icon = lazyLoad(() => import('@mui/icons-material/LooksTwo'));
-const H3Icon = lazyLoad(() => import('@mui/icons-material/Looks3'));
-const H4Icon = lazyLoad(() => import('@mui/icons-material/Looks4'));
-const H5Icon = lazyLoad(() => import('@mui/icons-material/Looks5'));
-const H6Icon = lazyLoad(() => import('@mui/icons-material/Looks6'));
+import React, { lazy } from 'react';
+
+const H1Icon = lazy(() => import('@mui/icons-material/LooksOne'));
+const H2Icon = lazy(() => import('@mui/icons-material/LooksTwo'));
+const H3Icon = lazy(() => import('@mui/icons-material/Looks3'));
+const H4Icon = lazy(() => import('@mui/icons-material/Looks4'));
+const H5Icon = lazy(() => import('@mui/icons-material/Looks5'));
+const H6Icon = lazy(() => import('@mui/icons-material/Looks6'));
 
 export default {
   h1: createHeadingsPlugin({

--- a/packages/plugins/content/slate/src/plugins/links/link.tsx
+++ b/packages/plugins/content/slate/src/plugins/links/link.tsx
@@ -1,8 +1,7 @@
-import { lazyLoad } from '@react-page/editor';
-import React from 'react';
+import React, { lazy } from 'react';
 import createComponentPlugin from '../../pluginFactories/createComponentPlugin';
 
-const LinkIcon = lazyLoad(() => import('@mui/icons-material/Link'));
+const LinkIcon = lazy(() => import('@mui/icons-material/Link'));
 
 type LinkData = {
   href: string;

--- a/packages/plugins/content/slate/src/plugins/lists/index.tsx
+++ b/packages/plugins/content/slate/src/plugins/lists/index.tsx
@@ -1,21 +1,20 @@
-import { lazyLoad } from '@react-page/editor';
-import React from 'react';
+import React, { lazy } from 'react';
 import { createListItemPlugin } from '../../pluginFactories';
 import createIndentionPlugin from '../../pluginFactories/createListIndentionPlugin';
 import createListPlugin from '../../pluginFactories/createListPlugin';
 import { LI, OL, UL } from './constants';
 
-const ListIcon = lazyLoad(
+const ListIcon = lazy(
   () => import('@mui/icons-material/FormatListBulleted')
 );
-const OrderedListIcon = lazyLoad(
+const OrderedListIcon = lazy(
   () => import('@mui/icons-material/FormatListNumbered')
 );
 
-const IncreaseIndentIcon = lazyLoad(
+const IncreaseIndentIcon = lazy(
   () => import('@mui/icons-material/FormatIndentIncrease')
 );
-const DecreaseIndentIcon = lazyLoad(
+const DecreaseIndentIcon = lazy(
   () => import('@mui/icons-material/FormatIndentDecrease')
 );
 

--- a/packages/plugins/content/slate/src/plugins/quotes.tsx
+++ b/packages/plugins/content/slate/src/plugins/quotes.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { lazyLoad } from '@react-page/editor';
+import React, { lazy } from 'react';
+
 import createSimpleHtmlBlockPlugin from '../pluginFactories/createSimpleHtmlBlockPlugin';
 
-const BlockquoteIcon = lazyLoad(
+const BlockquoteIcon = lazy(
   () => import('@mui/icons-material/FormatQuote')
 );
 

--- a/packages/plugins/content/spacer/src/Renderer/SpacerHtmlRenderer.tsx
+++ b/packages/plugins/content/spacer/src/Renderer/SpacerHtmlRenderer.tsx
@@ -1,17 +1,18 @@
 import type { CellPluginComponentProps } from '@react-page/editor';
-import { lazyLoad } from '@react-page/editor';
 
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import type { SpacerState } from '../types/state';
 
-const SpacerResizable = lazyLoad(() => import('./SpacerResizable'));
+const SpacerResizable = lazy(() => import('./SpacerResizable'));
 const SpacerHtmlRenderer: React.FC<CellPluginComponentProps<SpacerState>> = (
   props
 ) => {
   return (
     <div className={'react-page-plugins-content-spacer'}>
       {props.isEditMode ? (
-        <SpacerResizable {...props} />
+        <Suspense fallback={<div>Loading...</div>}>
+          <SpacerResizable {...props} />
+        </Suspense>
       ) : (
         <div style={{ height: `${(props.data?.height || 0).toString()}px` }} />
       )}

--- a/packages/plugins/content/spacer/src/createPlugin.tsx
+++ b/packages/plugins/content/spacer/src/createPlugin.tsx
@@ -1,12 +1,11 @@
 import type { CellPlugin } from '@react-page/editor';
-import { lazyLoad } from '@react-page/editor';
-import React from 'react';
+import React, { lazy } from 'react';
 import { defaultSettings } from './default/settings';
 
 import type { SpacerSettings } from './types/settings';
 import type { SpacerState } from './types/state';
 
-const AspectRatio = lazyLoad(() => import('@mui/icons-material/AspectRatio'));
+const AspectRatio = lazy(() => import('@mui/icons-material/AspectRatio'));
 const createPlugin: (settings: SpacerSettings) => CellPlugin<SpacerState> = (
   settings
 ) => {

--- a/packages/plugins/content/video/src/Renderer/VideoHtmlRenderer.tsx
+++ b/packages/plugins/content/video/src/Renderer/VideoHtmlRenderer.tsx
@@ -1,13 +1,11 @@
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import PlayArrow from '@mui/icons-material/PlayArrow';
 import { iconStyle } from '../common/styles';
-
-import { lazyLoad } from '@react-page/editor';
 
 import type { VideoHtmlRendererProps } from '../types/renderer';
 
 // react player is big, better lazy load it.
-const ReactPlayer = lazyLoad(() => import('react-player'));
+const ReactPlayer = lazy(() => import('react-player'));
 
 const Display: React.FC<VideoHtmlRendererProps> = ({ data, readOnly }) =>
   data?.src ? (
@@ -24,20 +22,24 @@ const Display: React.FC<VideoHtmlRendererProps> = ({ data, readOnly }) =>
           }}
         />
       )}
-      <ReactPlayer
-        url={data?.src}
-        height="100%"
-        width="100%"
-        style={{
-          position: 'absolute',
-          width: '100%',
-          height: '100%',
-        }}
-      />
+      <Suspense fallback={<div>Loading...</div>}>
+        <ReactPlayer
+          url={data?.src}
+          height="100%"
+          width="100%"
+          style={{
+            position: 'absolute',
+            width: '100%',
+            height: '100%',
+          }}
+        />
+      </Suspense>
     </div>
   ) : (
     <div className="react-page-plugins-content-video-placeholder">
-      <PlayArrow style={iconStyle} />
+      <Suspense fallback={<div>Loading...</div>}>
+        <PlayArrow style={iconStyle} />
+      </Suspense>
     </div>
   );
 

--- a/packages/plugins/content/video/src/default/settings.tsx
+++ b/packages/plugins/content/video/src/default/settings.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
+import React, { lazy } from 'react';
 import type { VideoSettings } from '../types/settings';
-import { lazyLoad } from '@react-page/editor';
 
-const PlayArrow = lazyLoad(() => import('@mui/icons-material/PlayArrow'));
+const PlayArrow = lazy(() => import('@mui/icons-material/PlayArrow'));
 
 export const defaultTranslations = {
   pluginName: 'Video',

--- a/packages/plugins/layout/background/src/createPlugin.tsx
+++ b/packages/plugins/layout/background/src/createPlugin.tsx
@@ -1,13 +1,12 @@
-import React from 'react';
+import React, { lazy } from 'react';
 
 import type { BackgroundSettings } from './types/settings';
 import type { BackgroundState } from './types/state';
 
 import { defaultSettings } from './default/settings';
 import type { CellPlugin } from '@react-page/editor';
-import { lazyLoad } from '@react-page/editor';
 
-const Icon = lazyLoad(() => import('@mui/icons-material/CropLandscape'));
+const Icon = lazy(() => import('@mui/icons-material/CropLandscape'));
 
 const createPlugin = (settings: BackgroundSettings) => {
   const mergedSettings = { ...defaultSettings, ...settings };

--- a/packages/plugins/layout/background/src/index.tsx
+++ b/packages/plugins/layout/background/src/index.tsx
@@ -6,9 +6,9 @@ import type { MakeOptional } from './types/makeOptional';
 import { ModeEnum } from './types/ModeEnum';
 
 export { ModeEnum };
-import { lazyLoad } from '@react-page/editor';
+import { lazy } from 'react';
 
-const BackgroundDefaultControls = lazyLoad(() => import('./Controls/Controls'));
+const BackgroundDefaultControls = lazy(() => import('./Controls/Controls'));
 
 export default (
   settings: MakeOptional<BackgroundSettings, 'Renderer' | 'Controls'>

--- a/packages/react-admin/src/index.tsx
+++ b/packages/react-admin/src/index.tsx
@@ -1,7 +1,7 @@
-import { lazyLoad } from '@react-page/editor';
+import { lazy } from 'react';
 
-// lazyload everything to avoid accidental bundle size increase
-export const RaReactPageInput = lazyLoad(() => import('./RaReactPageInput'));
-export const RaSelectReferenceInputField = lazyLoad(
+// lazy load everything to avoid accidental bundle size increase
+export const RaReactPageInput = lazy(() => import('./RaReactPageInput'));
+export const RaSelectReferenceInputField = lazy(
   () => import('./RaSelectReferenceInputField')
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -787,7 +787,7 @@
     "@babel/helper-validator-option" "^7.16.7"
     "@babel/plugin-transform-typescript" "^7.16.7"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.7", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.17.8"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz#3e56e4aff81befa55ac3ac6a0967349fd1c5bca2"
   integrity sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==
@@ -2024,15 +2024,6 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
-"@loadable/component@^5.15.0":
-  version "5.15.2"
-  resolved "https://registry.npmjs.org/@loadable/component/-/component-5.15.2.tgz#b6c418d592e0a64f16b1d614ca9d3b1443d3b498"
-  integrity sha512-ryFAZOX5P2vFkUdzaAtTG88IGnr9qxSdvLRvJySXcUA4B4xVWurUNADu3AnKPksxOZajljqTrDEDcYjeL4lvLw==
-  dependencies:
-    "@babel/runtime" "^7.7.7"
-    hoist-non-react-statics "^3.3.1"
-    react-is "^16.12.0"
-
 "@material-ui/core@^4.12.1":
   version "4.12.4"
   resolved "https://registry.npmjs.org/@material-ui/core/-/core-4.12.4.tgz#4ac17488e8fcaf55eb6a7f5efb2a131e10138a73"
@@ -2754,7 +2745,7 @@
     "@semantic-release/error" "^2.1.0"
     aggregate-error "^3.0.0"
     debug "^4.0.0"
-    execa "^4.0.0"
+    execa "^5.0.0"
     lodash "^4.17.4"
     parse-json "^5.0.0"
 
@@ -2973,13 +2964,6 @@
   version "7.0.11"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
-
-"@types/loadable__component@^5.13.3":
-  version "5.13.4"
-  resolved "https://registry.yarnpkg.com/@types/loadable__component/-/loadable__component-5.13.4.tgz#a4646b2406b1283efac1a9d9485824a905b33d4a"
-  integrity sha512-YhoCCxyuvP2XeZNbHbi8Wb9EMaUJuA2VGHxJffcQYrJKIKSkymJrhbzsf9y4zpTmr5pExAAEh5hbF628PAZ8Dg==
-  dependencies:
-    "@types/react" "*"
 
 "@types/lodash.debounce@4.0.4":
   version "4.0.4"
@@ -11767,7 +11751,7 @@ react-final-form@^6.5.7:
   dependencies:
     "@babel/runtime" "^7.15.4"
 
-react-is@^16.12.0, react-is@^16.13.1, react-is@^16.5.2, react-is@^16.6.0, react-is@^16.6.1, react-is@^16.7.0, react-is@^16.8.6:
+react-is@^16.13.1, react-is@^16.5.2, react-is@^16.6.0, react-is@^16.6.1, react-is@^16.7.0, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
See #1227 for what prompted this PR. 

After sleeping on it and reading up about how `@loadable/components` and `React.lazy` work, I figured it was worth a shot at trying to drop in and replace it. Incredibly, it worked. 

Mostly. See "Further Comments".

## Proposed changes
Vite can handle React's native lazy() function. For the reasons I mention in #1227 it seems natural to want to remove the dependency on `@loadable/components`, anyway.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Types of changes

<!-- What types of changes does your code introduce to react-page? -->
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Closing issues
Closes #1227
<!-- Put `Closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

## Further comments
In React 17, the `<Suspense>` component that provides the `fallback={...}` behavior provided by `@loadable/components` does **not** support SSR. [As of React 18, however, Suspense in SSR is supported](https://blog.saeloun.com/2022/01/20/new-suspense-ssr-architecture-in-react-18.html). So obviously this couldn't be merged without https://github.com/react-page/react-page/pull/1219 first. Perhaps this change could be incorporated in the overall upgrade, as I noticed that @gerom76 used a (probably better) way of adding the missing `children` types.

I'm not an expert, so I only added `<Suspense>` components where I found `fallback` property in use. It's possible the subtle differences between the two could require a more liberal sprinkling of Suspense throughout the component tree, aas I believe an error bubbles up to the nearest Suspense component, which could kill unreasonably large portions of the UI for no reason.

I should also add that `@emotion` is definitely still an issue. This fix reduced the error count in my issue #1227 from 4 to 2.
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
