### PR TITLE
feat: add reorder ability to ListItemField

### DIFF
--- a/packages/editor/src/ui/uniform-mui/ListDelField.tsx
+++ b/packages/editor/src/ui/uniform-mui/ListDelField.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import React from 'react';
 import type { FieldProps } from 'uniforms';
 import { connectField, filterDOMProps, joinName, useField } from 'uniforms';
+import DeleteForeverRoundedIcon from '@mui/icons-material/DeleteForeverRounded';
 
 export type ListDelFieldProps = FieldProps<
   unknown,
@@ -13,7 +14,7 @@ export type ListDelFieldProps = FieldProps<
 
 function ListDel({
   disabled,
-  icon = '-',
+  icon = <DeleteForeverRoundedIcon />,
   name,
   readOnly,
   ...props
@@ -28,15 +29,16 @@ function ListDel({
   )[0];
 
   const limitNotReached =
-    !disabled && !(parent.minCount! >= parent.value!.length);
+    !disabled && !(parent.minCount ?? 0 >= (parent.value ?? []).length);
 
   return (
     <IconButton
       {...filterDOMProps(props)}
       disabled={!limitNotReached}
+      sx={{ padding: 0 }}
       onClick={() => {
         if (!readOnly) {
-          const value = parent.value!.slice();
+          const value = (parent.value ?? []).slice();
           value.splice(nameIndex, 1);
           parent.onChange(value);
         }

--- a/packages/editor/src/ui/uniform-mui/ListField.tsx
+++ b/packages/editor/src/ui/uniform-mui/ListField.tsx
@@ -3,11 +3,12 @@ import ListMaterial from '@mui/material/List';
 import ListSubheader from '@mui/material/ListSubheader';
 import type { ReactNode } from 'react';
 import React, { Children, cloneElement, isValidElement } from 'react';
-import type { FieldProps } from 'uniforms';
+import { useDrop } from 'react-dnd';
+import { FieldProps } from 'uniforms';
 import { connectField, filterDOMProps } from 'uniforms';
 
 import ListAddField from './ListAddField';
-import ListItemField from './ListItemField';
+import ListItemField, { DragItemType } from './ListItemField';
 
 export type ListFieldProps = FieldProps<
   unknown[],
@@ -28,9 +29,12 @@ function List({
   value,
   ...props
 }: ListFieldProps) {
+  const [, drop] = useDrop(() => ({ accept: DragItemType.ListItemField }));
+
   return (
     <>
       <ListMaterial
+        ref={drop}
         dense
         subheader={
           label ? (

--- a/packages/editor/src/ui/uniform-mui/ListField.tsx
+++ b/packages/editor/src/ui/uniform-mui/ListField.tsx
@@ -4,7 +4,7 @@ import ListSubheader from '@mui/material/ListSubheader';
 import type { ReactNode } from 'react';
 import React, { Children, cloneElement, isValidElement } from 'react';
 import { useDrop } from 'react-dnd';
-import { FieldProps } from 'uniforms';
+import type { FieldProps } from 'uniforms';
 import { connectField, filterDOMProps } from 'uniforms';
 
 import ListAddField from './ListAddField';
@@ -16,7 +16,7 @@ export type ListFieldProps = FieldProps<
   {
     addIcon?: ReactNode;
     initialCount?: number;
-    itemProps?: Record<string, any>;
+    itemProps?: Record<string, unknown>;
   }
 >;
 

--- a/packages/editor/src/ui/uniform-mui/ListItemField.tsx
+++ b/packages/editor/src/ui/uniform-mui/ListItemField.tsx
@@ -87,12 +87,14 @@ function ListItem({
     [moveItem]
   );
 
+  const disableSort = disableSortable ?? (parent.value ?? []).length < 2;
+
   return (
     <ListItemMaterial
       dense={dense}
       disableGutters={disableGutters}
       divider={divider}
-      ref={(node) => drag(drop(node))}
+      ref={(node) => (disableSort ? null : drag(drop(node)))}
       sx={{ gap: '0.5rem' }}
     >
       <ListSortField
@@ -101,7 +103,7 @@ function ListItem({
         iconDown={moveItemDownIcon}
         handleMove={moveItem}
         dragIcon={dragIcon}
-        disabled={disableSortable}
+        disabled={disableSort}
       />
 
       {children}

--- a/packages/editor/src/ui/uniform-mui/ListItemField.tsx
+++ b/packages/editor/src/ui/uniform-mui/ListItemField.tsx
@@ -1,12 +1,27 @@
-import type { ListItemProps } from '@mui/material/ListItem';
-import ListItemMaterial from '@mui/material/ListItem';
 import type { ReactNode } from 'react';
 import React from 'react';
-import { connectField } from 'uniforms';
+
+import { IconButton } from '@mui/material';
+import type { ListItemProps } from '@mui/material/ListItem';
+import ListItemMaterial from '@mui/material/ListItem';
+import Stack from '@mui/material/Stack';
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+
+import { useDrag, useDrop } from 'react-dnd';
+import { connectField, joinName, useField } from 'uniforms';
 
 import AutoField from './AutoField';
 import ListDelField from './ListDelField';
 import ListSortField from './ListSortField';
+
+export enum DragItemType {
+  ListItemField = 'ListItemField',
+}
+
+interface DragItem {
+  name: string;
+  originalIndex: number;
+}
 
 export type ListItemFieldProps = {
   children?: ReactNode;
@@ -14,7 +29,11 @@ export type ListItemFieldProps = {
   disableGutters?: ListItemProps['disableGutters'];
   divider?: ListItemProps['divider'];
   removeIcon?: ReactNode;
+  dragIcon?: ReactNode;
+  moveItemUpIcon?: ReactNode;
+  moveItemDownIcon?: ReactNode;
   value?: unknown;
+  name?: string;
 };
 
 function ListItem({
@@ -23,14 +42,74 @@ function ListItem({
   disableGutters,
   divider,
   removeIcon,
+  moveItemDownIcon,
+  moveItemUpIcon,
+  dragIcon = <DragIndicatorIcon />,
+  value,
+  name,
 }: ListItemFieldProps) {
+  const nameParts = joinName(null, name);
+  const nameIndex = +nameParts[nameParts.length - 1];
+  const parentName = joinName(nameParts.slice(0, -1));
+
+  const parent = useField<{}, unknown[]>(
+    parentName,
+    {},
+    { absoluteName: true }
+  )[0];
+
+  const moveItem = (fromIndex: number, toIndex: number) => {
+    const value = parent.value!.slice();
+    value.splice(fromIndex, 1);
+    value.splice(toIndex, 0, parent.value![fromIndex]);
+    parent.onChange(value);
+  };
+
+  const [{ isDragging }, drag] = useDrag<
+    DragItem,
+    unknown,
+    {
+      isDragging: boolean;
+    }
+  >(
+    () => ({
+      type: DragItemType.ListItemField,
+      item: { name, originalIndex: nameIndex } as DragItem,
+      collect: (monitor) => ({
+        isDragging: monitor.isDragging(),
+      }),
+    }),
+    [value, nameIndex, moveItem]
+  );
+
+  const [, drop] = useDrop(
+    () => ({
+      accept: DragItemType.ListItemField,
+      drop: (draggedItem: DragItem, monitor) => {
+        const didDrop = monitor.canDrop();
+        if (didDrop && draggedItem.name !== name)
+          moveItem(draggedItem.originalIndex, nameIndex);
+      },
+    }),
+    [moveItem]
+  );
+
   return (
     <ListItemMaterial
       dense={dense}
       disableGutters={disableGutters}
       divider={divider}
+      ref={(node) => drag(drop(node))}
     >
-      <ListSortField name="" />
+      <Stack>
+        <IconButton size="large">{dragIcon}</IconButton>
+        <ListSortField
+          name=""
+          iconDown={moveItemDownIcon}
+          iconUp={moveItemUpIcon}
+          handleMove={moveItem}
+        />
+      </Stack>
       {children}
       <ListDelField name="" icon={removeIcon} />
     </ListItemMaterial>

--- a/packages/editor/src/ui/uniform-mui/ListItemField.tsx
+++ b/packages/editor/src/ui/uniform-mui/ListItemField.tsx
@@ -6,6 +6,7 @@ import { connectField } from 'uniforms';
 
 import AutoField from './AutoField';
 import ListDelField from './ListDelField';
+import ListSortField from './ListSortField';
 
 export type ListItemFieldProps = {
   children?: ReactNode;
@@ -29,6 +30,7 @@ function ListItem({
       disableGutters={disableGutters}
       divider={divider}
     >
+      <ListSortField name="" />
       {children}
       <ListDelField name="" icon={removeIcon} />
     </ListItemMaterial>

--- a/packages/editor/src/ui/uniform-mui/ListSortField.tsx
+++ b/packages/editor/src/ui/uniform-mui/ListSortField.tsx
@@ -9,13 +9,18 @@ import { connectField, filterDOMProps, joinName, useField } from 'uniforms';
 export type ListSortFieldProps = FieldProps<
   unknown,
   IconButtonProps,
-  { iconUp?: ReactNode; iconDown?: ReactNode }
+  {
+    iconUp?: ReactNode;
+    iconDown?: ReactNode;
+    handleMove: (fromIndex: number, toIndex: number) => void;
+  }
 >;
 
 function ListSort({
   disabled,
   iconUp = '↑',
   iconDown = '↓',
+  handleMove,
   name,
   readOnly,
   ...props
@@ -24,7 +29,7 @@ function ListSort({
   const nameIndex = +nameParts[nameParts.length - 1];
   const parentName = joinName(nameParts.slice(0, -1));
 
-  const parent = useField<{ minCount?: number }, unknown[]>(
+  const parent = useField<{}, unknown[]>(
     parentName,
     {},
     { absoluteName: true }
@@ -35,25 +40,12 @@ function ListSort({
   const limitNotReachedDown =
     !disabled && nameIndex !== parent.value!.length - 1;
 
-  const handleMove = (moveWhere: 'up' | 'down') => {
-    if (!readOnly) {
-      const value = parent.value!.slice();
-      value.splice(nameIndex, 1);
-      value.splice(
-        moveWhere === 'up' ? nameIndex - 1 : nameIndex + 1,
-        0,
-        parent.value![nameIndex]
-      );
-      parent.onChange(value);
-    }
-  };
-
   return (
     <Stack>
       <IconButton
         {...filterDOMProps(props)}
         disabled={!limitNotReachedUp}
-        onClick={() => handleMove('up')}
+        onClick={() => handleMove(nameIndex, nameIndex - 1)}
         size="large"
       >
         {iconUp}
@@ -61,7 +53,7 @@ function ListSort({
       <IconButton
         {...filterDOMProps(props)}
         disabled={!limitNotReachedDown}
-        onClick={() => handleMove('down')}
+        onClick={() => handleMove(nameIndex, nameIndex + 1)}
         size="large"
       >
         {iconDown}

--- a/packages/editor/src/ui/uniform-mui/ListSortField.tsx
+++ b/packages/editor/src/ui/uniform-mui/ListSortField.tsx
@@ -23,6 +23,7 @@ function ListSort({
   const nameParts = joinName(null, name);
   const nameIndex = +nameParts[nameParts.length - 1];
   const parentName = joinName(nameParts.slice(0, -1));
+
   const parent = useField<{ minCount?: number }, unknown[]>(
     parentName,
     {},
@@ -34,35 +35,34 @@ function ListSort({
   const limitNotReachedDown =
     !disabled && nameIndex !== parent.value!.length - 1;
 
+  const handleMove = (moveWhere: 'up' | 'down') => {
+    if (!readOnly) {
+      const value = parent.value!.slice();
+      value.splice(nameIndex, 1);
+      value.splice(
+        moveWhere === 'up' ? nameIndex - 1 : nameIndex + 1,
+        0,
+        parent.value![nameIndex]
+      );
+      parent.onChange(value);
+    }
+  };
+
   return (
     <Stack>
       <IconButton
         {...filterDOMProps(props)}
         disabled={!limitNotReachedUp}
-        onClick={() => {
-          if (!readOnly) {
-            const value = parent.value!.slice();
-            value.splice(nameIndex, 1);
-            value.splice(nameIndex - 1, 0, parent.value![nameIndex]);
-            parent.onChange(value);
-          }
-        }}
-        size="small"
+        onClick={() => handleMove('up')}
+        size="large"
       >
         {iconUp}
       </IconButton>
       <IconButton
         {...filterDOMProps(props)}
         disabled={!limitNotReachedDown}
-        onClick={() => {
-          if (!readOnly) {
-            const value = parent.value!.slice();
-            value.splice(nameIndex, 1);
-            value.splice(nameIndex + 1, 0, parent.value![nameIndex]);
-            parent.onChange(value);
-          }
-        }}
-        size="small"
+        onClick={() => handleMove('down')}
+        size="large"
       >
         {iconDown}
       </IconButton>

--- a/packages/editor/src/ui/uniform-mui/ListSortField.tsx
+++ b/packages/editor/src/ui/uniform-mui/ListSortField.tsx
@@ -1,10 +1,17 @@
+import { ButtonGroup, Stack, styled } from '@mui/material';
 import type { IconButtonProps } from '@mui/material/IconButton';
-import IconButton from '@mui/material/IconButton';
-import { Stack } from '@mui/system';
+import IconButtonMaterial from '@mui/material/IconButton';
+
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+
 import type { ReactNode } from 'react';
 import React from 'react';
 import type { FieldProps } from 'uniforms';
 import { connectField, filterDOMProps, joinName, useField } from 'uniforms';
+
+const IconButton = styled(IconButtonMaterial)({ padding: 0 });
 
 export type ListSortFieldProps = FieldProps<
   unknown,
@@ -12,14 +19,16 @@ export type ListSortFieldProps = FieldProps<
   {
     iconUp?: ReactNode;
     iconDown?: ReactNode;
+    dragIcon?: ReactNode;
     handleMove: (fromIndex: number, toIndex: number) => void;
   }
 >;
 
 function ListSort({
   disabled,
-  iconUp = '↑',
-  iconDown = '↓',
+  iconUp = <ArrowUpwardIcon />,
+  iconDown = <ArrowDownwardIcon />,
+  dragIcon = <DragIndicatorIcon />,
   handleMove,
   name,
   readOnly,
@@ -29,7 +38,7 @@ function ListSort({
   const nameIndex = +nameParts[nameParts.length - 1];
   const parentName = joinName(nameParts.slice(0, -1));
 
-  const parent = useField<{}, unknown[]>(
+  const parent = useField<Record<string, unknown>, unknown[]>(
     parentName,
     {},
     { absoluteName: true }
@@ -38,26 +47,34 @@ function ListSort({
   const limitNotReachedUp = !disabled && nameIndex !== 0;
 
   const limitNotReachedDown =
-    !disabled && nameIndex !== parent.value!.length - 1;
+    !disabled && nameIndex !== (parent.value ?? []).length - 1;
 
   return (
-    <Stack>
+    <Stack direction="row">
       <IconButton
-        {...filterDOMProps(props)}
-        disabled={!limitNotReachedUp}
-        onClick={() => handleMove(nameIndex, nameIndex - 1)}
+        disabled={(parent.value ?? []).length < 2}
         size="large"
+        sx={{ padding: 0 }}
       >
-        {iconUp}
+        {dragIcon}
       </IconButton>
-      <IconButton
-        {...filterDOMProps(props)}
-        disabled={!limitNotReachedDown}
-        onClick={() => handleMove(nameIndex, nameIndex + 1)}
-        size="large"
-      >
-        {iconDown}
-      </IconButton>
+
+      <ButtonGroup orientation="vertical" size="large">
+        <IconButton
+          {...filterDOMProps(props)}
+          disabled={!limitNotReachedUp}
+          onClick={() => handleMove(nameIndex, nameIndex - 1)}
+        >
+          {iconUp}
+        </IconButton>
+        <IconButton
+          {...filterDOMProps(props)}
+          disabled={!limitNotReachedDown}
+          onClick={() => handleMove(nameIndex, nameIndex + 1)}
+        >
+          {iconDown}
+        </IconButton>
+      </ButtonGroup>
     </Stack>
   );
 }

--- a/packages/editor/src/ui/uniform-mui/ListSortField.tsx
+++ b/packages/editor/src/ui/uniform-mui/ListSortField.tsx
@@ -1,0 +1,76 @@
+import type { IconButtonProps } from '@mui/material/IconButton';
+import IconButton from '@mui/material/IconButton';
+import { Stack } from '@mui/system';
+import type { ReactNode } from 'react';
+import React from 'react';
+import type { FieldProps } from 'uniforms';
+import { connectField, filterDOMProps, joinName, useField } from 'uniforms';
+
+export type ListSortFieldProps = FieldProps<
+  unknown,
+  IconButtonProps,
+  { iconUp?: ReactNode; iconDown?: ReactNode }
+>;
+
+function ListSort({
+  disabled,
+  iconUp = '↑',
+  iconDown = '↓',
+  name,
+  readOnly,
+  ...props
+}: ListSortFieldProps) {
+  const nameParts = joinName(null, name);
+  const nameIndex = +nameParts[nameParts.length - 1];
+  const parentName = joinName(nameParts.slice(0, -1));
+  const parent = useField<{ minCount?: number }, unknown[]>(
+    parentName,
+    {},
+    { absoluteName: true }
+  )[0];
+
+  const limitNotReachedUp = !disabled && nameIndex !== 0;
+
+  const limitNotReachedDown =
+    !disabled && nameIndex !== parent.value!.length - 1;
+
+  return (
+    <Stack>
+      <IconButton
+        {...filterDOMProps(props)}
+        disabled={!limitNotReachedUp}
+        onClick={() => {
+          if (!readOnly) {
+            const value = parent.value!.slice();
+            value.splice(nameIndex, 1);
+            value.splice(nameIndex - 1, 0, parent.value![nameIndex]);
+            parent.onChange(value);
+          }
+        }}
+        size="small"
+      >
+        {iconUp}
+      </IconButton>
+      <IconButton
+        {...filterDOMProps(props)}
+        disabled={!limitNotReachedDown}
+        onClick={() => {
+          if (!readOnly) {
+            const value = parent.value!.slice();
+            value.splice(nameIndex, 1);
+            value.splice(nameIndex + 1, 0, parent.value![nameIndex]);
+            parent.onChange(value);
+          }
+        }}
+        size="small"
+      >
+        {iconDown}
+      </IconButton>
+    </Stack>
+  );
+}
+
+export default connectField<ListSortFieldProps>(ListSort, {
+  initialValue: false,
+  kind: 'leaf',
+});


### PR DESCRIPTION
Add the ability to reorder ListItemField items complementary to the ListDelField

## Proposed changes
addition of ListSortField, two buttons, with similar logic of ListDelField button that helps user change the order of the items on the list.
 
## Types of changes
On the left side of the ListItemField component, as the delete button is on the right, so to prevent unintended deletions, addition of two buttons that allow a user to reorder the items on the list, either push the item up (if the item not already the first) and down (if the item is not already at the bottom)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

