### PR TITLE
fix: language switch debounce bug

### DIFF
--- a/packages/editor/src/core/components/hooks/node.ts
+++ b/packages/editor/src/core/components/hooks/node.ts
@@ -356,6 +356,7 @@ export const useDebouncedCellData = (nodeId: string) => {
   const dataRef = useRef(cellData);
 
   const currentLang = useLang();
+  const langRef = useRef(currentLang);
   const cellDataRef = useRef(cellData);
 
   const updateCellDataImmediate = useUpdateCellData(nodeId);
@@ -381,13 +382,20 @@ export const useDebouncedCellData = (nodeId: string) => {
     }
   }, [changed, cellData]);
 
+  useEffect(() => {
+    // this again is a bit hacky but due to debouncing
+    // it keeps the old currentLang in the first change when switching
+    // language and then it messes with the other languages values
+    langRef.current = currentLang;
+  }, [currentLang]);
+
   const onChange = useCallback(
     (
       partialData: Record<string, unknown>,
       options?: CellPluginOnChangeOptions
     ) => {
       // special handling if non default language is changed (special custom code)
-      if (options?.lang && options.lang !== currentLang) {
+      if (options?.lang && options.lang !== langRef.current) {
         // this hook is a bit hacky, because we keep around state of changes and debounce changes
         // its probably not the cleanest solution
         // however this handling is problematic, if you change any other language.


### PR DESCRIPTION
Fix language switch debounce bug

## Proposed changes

Currently when switching language the first change you make in the second language affects the contents of the first language because of currentLanguage not changing due to debounce issues. As a quick fix I introduce a ref that hols the lang and behaves correctly then.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Closing issues

## Further comments
