### PR TITLE
fix: changing language might override text in other language in slate

### DIFF
--- a/packages/plugins/content/slate/src/components/SlateProvider.tsx
+++ b/packages/plugins/content/slate/src/components/SlateProvider.tsx
@@ -42,7 +42,7 @@ const SlateProvider: FC<PropsWithChildren<SlateProps>> = (props) => {
       if (
         !deepEquals(editor.children, data?.slate) ||
         !deepEquals(editor.selection, data?.selection)
-      )
+      ) {
         props.onChange(
           {
             slate: editor.children,
@@ -54,8 +54,9 @@ const SlateProvider: FC<PropsWithChildren<SlateProps>> = (props) => {
             notUndoable: deepEquals(editor.children, data?.slate),
           }
         );
+      }
     },
-    [data?.slate]
+    [data?.slate, props.onChange]
   );
 
   const initialValue = data?.slate;


### PR DESCRIPTION
fixes a rather nasty bug that was introduced recently.

This also finally simplify the complicated `useDebouncedCellData`-hook.

i _hope_ that this does not introduce a new problem, but it looks good so far